### PR TITLE
visualeditor loading timeout fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,22 @@
 
     wfLoadExtension( 'Cite' );
     wfLoadExtension( 'PageForms' );
+
+    /* Mediawiki Performance tuning */
+    // https://www.mediawiki.org/wiki/Manual:Performance_tuning
+    // https://www.mediawiki.org/wiki/User:Ilmari_Karonen/Performance_tuning
+
+    // PHP cache & lifetime
+    $wgMainCacheType = CACHE_ACCEL;
+    $wgMessageCacheType = CACHE_ACCEL;
+    $wgParserCacheType = CACHE_DB;
+
+    $wgParserCacheExpireTime = 63072000;
+    $wgRevisionCacheExpiry = 63072000;
+    $wgResourceLoaderMaxage = [
+      'versioned' => 63072000,
+      'unversioned' => 63072000
+    ];
   ```
 
   </details>


### PR DESCRIPTION
It gets time outed when the request exceeds 30 seconds.

The visual editor was failing while waiting for this API call:
`https://localhost/w/api.php?action=visualeditor&format=json&paction=parse&page=Baseball&uselang=en&formatversion=2`

I was not able to increase the time limit, however adding `$wgMainCacheType = CACHE_ACCEL;` significantly increased performance.

Now large articles (Baseball as an example) takes ~11s instead of ~60s initially to load inside of the VisualEditor.