### PR TITLE
rename article through the XML dump

### DIFF
--- a/backend/src/helpers/MediawikiClient.ts
+++ b/backend/src/helpers/MediawikiClient.ts
@@ -155,44 +155,13 @@ class MediawikiClient {
     this.logout(csrftoken);
   }
 
-  private async renameArticle(title: string, articleId: string): Promise<void> {
-    const csrftoken = await this.loginAndGetCsrf();
-
-    logger.info(
-      `Renaming Article ${title} to its corresponding id: ${articleId}`
-    );
-
-    const { data } = await this.mediawikiApiInstance.post(
-      '',
-      {
-        action: 'move',
-        from: title,
-        to: articleId,
-        noredirect: true,
-        token: csrftoken,
-        format: 'json'
-      },
-      {
-        headers: {
-          'Content-Type': 'application/x-www-form-urlencoded'
-        }
-      }
-    );
-
-    if (data.error) {
-      logger.error(`Failed to rename article: ${data.error.info}`);
-      this.logout(csrftoken);
-      throw new Error(`Failed to rename article with id ${articleId}`);
-    }
-    this.logout(csrftoken);
-  }
-
   async importNewArticle(articleId: string, title: string): Promise<void> {
     try {
       // Export
       logger.info(`Exporting file ${title}`);
       const exportData = await this.wikipediaApi.exportArticleData(
         title,
+        articleId,
         this.language
       );
       logger.info(`Successfully exported file ${title}`);
@@ -201,9 +170,6 @@ class MediawikiClient {
       logger.info(`Importing into our instance file ${title}`);
       await this.mediawikiAutomator.importMediaWikiPage(articleId, exportData);
       logger.info(`Successfully imported file ${title}`);
-
-      // Rename
-      await this.renameArticle(title, articleId);
     } catch (error) {
       logger.error(`Error importing article ${title}`, error);
       throw error;

--- a/backend/src/helpers/WikipediaApiInteractor.ts
+++ b/backend/src/helpers/WikipediaApiInteractor.ts
@@ -80,7 +80,11 @@ export default class WikipediaApiInteractor implements WikipediaInteractor {
     return htmlString;
   }
 
-  async exportArticleData(title: string, language: string): Promise<string> {
+  async exportArticleData(
+    title: string,
+    articleId: string,
+    language: string
+  ): Promise<string> {
     const exportResponse = await axios.get(`${this.wpProxy}/w/index.php`, {
       params: {
         title: 'Special:Export',
@@ -103,6 +107,7 @@ export default class WikipediaApiInteractor implements WikipediaInteractor {
           exportData,
           language,
           title,
+          articleId,
           this.getWikipediaHTML.bind(this)
         );
         resolve(exportData);

--- a/backend/src/helpers/parsingHelper.ts
+++ b/backend/src/helpers/parsingHelper.ts
@@ -278,12 +278,19 @@ export async function processExportedArticle(
   exportData: string,
   sourceLanguage: string,
   title: string,
+  articleId: string,
   getWikipediaHTML: (title: string, language: string) => Promise<string>
 ): Promise<string> {
   // Add missing </base> into the file. (Exported files from proxies only)
   let processedData = exportData.replace(
     '\n    <generator>',
     '</base>\n    <generator>'
+  );
+
+  // Rename article
+  processedData = processedData.replace(
+    /<title>(.*?)<\/title>/s,
+    `<title>${articleId}</title>`
   );
 
   // Externalize article sources to wikipedia


### PR DESCRIPTION
:point_up_2: Rename article directly through the XML dump instead of a rename API call

:point_right: resolves #258 because it would fix the underlying problem, which was to import the article to the real name, and then rename (thus destroying the old real article).

:point_right: It mildly optimizes importing performance. 