### PR TITLE
use more mediawiki default link format

### DIFF
--- a/backend/src/controllers/auth.controller.ts
+++ b/backend/src/controllers/auth.controller.ts
@@ -21,7 +21,7 @@ export default async function restrictMediawikiAccess(
 
   try {
     const articleIdRegEx = new RegExp(
-      `^/(${wikiadviserLanguagesRegex})/index.php/([0-9a-f-]{1,36})([?/]|$)`,
+      `^/(${wikiadviserLanguagesRegex})/index.php?title=([0-9a-f-]{1,36})(&|$)`,
       'i'
     );
 

--- a/frontend/src/components/DiffCard.vue
+++ b/frontend/src/components/DiffCard.vue
@@ -226,7 +226,7 @@ const onSwitchTabEmitChange = (tab: string) => {
 
 function viewArticleInNewTab() {
   window.open(
-    `${process.env.MEDIAWIKI_ENDPOINT}/${props.article.language}/index.php/${props.article.article_id}`,
+    `${process.env.MEDIAWIKI_ENDPOINT}/${props.article.language}/index.php?title=${props.article.article_id}`,
     '_blank'
   );
 }

--- a/frontend/src/components/MwVisualEditor.vue
+++ b/frontend/src/components/MwVisualEditor.vue
@@ -32,7 +32,7 @@ const props = defineProps({
   buttonToggle: { type: String, required: true },
 });
 const $q = useQuasar();
-const articleLink = `${process.env.MEDIAWIKI_ENDPOINT}/${props.article.language}/index.php/${props.article.article_id}?veaction=edit&expectedTitle=${props.article.title}`;
+const articleLink = `${process.env.MEDIAWIKI_ENDPOINT}/${props.article.language}/index.php?title=${props.article.article_id}&veaction=edit&expectedTitle=${props.article.title}`;
 const loader = {
   editor: { value: true, message: 'Loading Editor' },
   changes: {


### PR DESCRIPTION
for example read button uses `title=` format instead of a `/`
![image](https://github.com/ankaboot-source/wikiadviser/assets/73950268/9419fbcf-badf-411f-b687-8acfe89e1e9b)
