### PR TITLE
disabling cadviser | promtail for mediawiki

### DIFF
--- a/.github/workflows/monitoring-deploy.yml
+++ b/.github/workflows/monitoring-deploy.yml
@@ -97,3 +97,6 @@ jobs:
 
             # Start monitoring exporters 
             docker compose up -d;
+            docker stop monitoring-agent-cadvisor-1
+            docker stop monitoring-agent-promtail-1
+            docker container prune


### PR DESCRIPTION
- We are running same docker-compose containing 3 services node-exporter, cadvisor, promtail, for wikiadviser we need all of them but mediawiki we need just node-exporter for now, we can reactivate promtail in the future if you guys needed to check on apache logs, for now im disabling them to conserve the resources.