### PR TITLE
Button revert too close to the profile picture (no margin)

### DIFF
--- a/frontend/src/pages/auth/UserAccountPage.vue
+++ b/frontend/src/pages/auth/UserAccountPage.vue
@@ -119,7 +119,7 @@ const defaultAvatar = computed(
             :show="!defaultAvatar"
             :loading="revertingImage"
             outline
-            class-name="text-sm"
+            class-name="text-sm q-mt-md"
             icon="no_photography"
             color="primary"
             label="Revert to default avatar"


### PR DESCRIPTION
![Screenshot from 2024-01-22 11-26-33](https://github.com/ankaboot-source/wikiadviser/assets/152849306/829baff7-b599-4e9e-8102-cee40aad7a28)
