### PR TITLE
Authorize edit source 

### DIFF
--- a/backend/src/controllers/auth.controller.ts
+++ b/backend/src/controllers/auth.controller.ts
@@ -25,7 +25,7 @@ export default async function restrictMediawikiAccess(
     const user = await authHandler.verifyCookie(req);
 
     const articleIdRegEx = new RegExp(
-      `^/(${wikiadviserLanguagesRegex})/index.php(\\?title=|/)([0-9a-f-]{36})(&|$|?)`,
+      `^/(${wikiadviserLanguagesRegex})/index.php(\\?title=|/)([0-9a-f-]{36})(&|$|\\?)`,
       'i'
     );
 


### PR DESCRIPTION
resolves #546 
E.g.: `https://wiki-demo.wikiadviser.io/en/index.php/2efb3d21-9fc3-4464-b9c2-68be69f6371a?action=edit&veswitched=1&vehidebetadialog=1`