### PR TITLE
remove EmbedVideo extension

### DIFF
--- a/mediawiki-setup/LocalSettings.php
+++ b/mediawiki-setup/LocalSettings.php
@@ -233,7 +233,6 @@ wfLoadExtension( 'GeoData' );
 wfLoadExtension( 'MultimediaViewer' );
 wfLoadExtension( 'TimedMediaHandler' );
 $wgFFmpegLocation = '/usr/bin/ffmpeg';
-wfLoadExtension( 'EmbedVideo' );
 wfLoadExtension( 'ExternalData' );
 wfLoadExtension( 'RegularTooltips' );
 wfLoadExtension( 'HTMLTags' );

--- a/mediawiki-setup/mediawiki-setup.sh
+++ b/mediawiki-setup/mediawiki-setup.sh
@@ -337,13 +337,6 @@ for environment in "${environments[@]}"; do
     done
 done
 
-# EmbedVideo
-for environment in "${environments[@]}"; do
-    for lang in "${languages[@]}"; do
-         git clone https://github.com/StarCitizenWiki/mediawiki-extensions-EmbedVideo.git /var/www/wiki-$environment/$lang/extensions/EmbedVideo
-    done
-done
-
 # ExternalData
 for environment in "${environments[@]}"; do
     for lang in "${languages[@]}"; do


### PR DESCRIPTION
we already have TimedMediaHandler used by wikipedia and doing good job displaying medias, EmbedVideo diplayed audio and didn't display videos correctly