### PR TITLE
Ellipsify long article's title & description

### DIFF
--- a/frontend/src/components/AppHeader.vue
+++ b/frontend/src/components/AppHeader.vue
@@ -118,5 +118,4 @@ function account() {
     max-width: 40vw;
   }
 }
-
 </style>


### PR DESCRIPTION
I discovered a bug that needed to be corrected using media query CSS when we wanted to ellipsis the title. Additionally, I discovered that this answer from stackoverflow https://stackoverflow.com/questions/17779293/css-text-overflow-ellipsis-not-working is useful in understanding the issue.
![Screenshot from 2024-02-20 10-49-24](https://github.com/ankaboot-source/wikiadviser/assets/152849306/6ce5bde2-a573-4d50-b932-39700337c1d3)
![Screenshot from 2024-02-20 10-49-55](https://github.com/ankaboot-source/wikiadviser/assets/152849306/d50e84d1-eb73-4a4d-8f77-f72786700441)