### PR TITLE
add code coverage badge using deepsource

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![DeepSource](https://app.deepsource.com/gh/ankaboot-source/wikiadviser.svg/?label=code+coverage&show_trend=true&token=ZTDAa-DQcTJvNvMiXJlquOHn)](https://app.deepsource.com/gh/ankaboot-source/wikiadviser/)
+
 # Wikiadviser
 
 ## MediaWiki


### PR DESCRIPTION
resolves #447 
![image](https://github.com/ankaboot-source/wikiadviser/assets/73950268/94c20bee-4f12-462d-b4b1-c1c4508fa48a)
