### PR TITLE
 Convert certain templates to links

### DIFF
--- a/backend/src/helpers/parsingHelper.ts
+++ b/backend/src/helpers/parsingHelper.ts
@@ -420,11 +420,11 @@ function convertSourceTemplateToLink(
   pageContent: string,
   sourceLanguage: string
 ) {
-  return pageContent.replace(/{{Lnobr\|([\s\S]*?)}}/gi, (_, group) => {
-    return group.includes('|')
+  return pageContent.replace(/{{Lnobr\|([\s\S]*?)}}/gi, (_, group) =>
+    group.includes('|')
       ? `[[wikipedia:${sourceLanguage}:${group}]]`
-      : `[[wikipedia:${sourceLanguage}:${group}|${group}]]`;
-  });
+      : `[[wikipedia:${sourceLanguage}:${group}|${group}]]`
+  );
 }
 
 /**


### PR DESCRIPTION
resolves #632
 * Converts certain templates to links.
 * This function modifies the following templates:
 *  - lnobr
 *
 * @param pageContent The content of the page containing templates.
 * @param sourceLanguage The source language prefix for Wikipedia articles.
 * @returns The updated page content with links instead of certain templates.
![image](https://github.com/ankaboot-source/wikiadviser/assets/73950268/20bc1c47-c64e-48c2-9106-228b9327486a)
