### PR TITLE
Fix Header article title missing ellipsis

### DIFF
--- a/frontend/src/components/AppHeader.vue
+++ b/frontend/src/components/AppHeader.vue
@@ -10,11 +10,14 @@
           />
           <q-breadcrumbs-el
             v-if="article?.title"
-            :label="article.title"
             class="article-title"
             to="."
             @click="$router.go(0)"
-          />
+          >
+            <div class="ellipsis">
+              {{ article.title }}
+            </div>
+          </q-breadcrumbs-el>
           <q-icon v-if="article?.web_publication" name="public">
             <q-tooltip>This article is published on the Web</q-tooltip>
           </q-icon>


### PR DESCRIPTION
resolves #643 
![image](https://github.com/ankaboot-source/wikiadviser/assets/73950268/4aebb879-abb2-42cd-8a78-43f4cd495393)
