### PR TITLE
Fix default ENV.SHARE_LINK_DAY_LIMIT

### DIFF
--- a/frontend/src/utils/consts/index.ts
+++ b/frontend/src/utils/consts/index.ts
@@ -1,6 +1,6 @@
 import ENV from 'src/schema/env.schema';
 
-export const EXPIRATION_DAYS = ENV.SHARE_LINK_DAY_LIMIT;
+export const EXPIRATION_DAYS = ENV.SHARE_LINK_DAY_LIMIT || 2;
 
 export const MAX_EMAIL_LENGTH = 20;
 


### PR DESCRIPTION
- resolves #672 
- `z.coerce.number().default(2)` of an empty string `''` would return `0` instead of the default which is `2`