### PR TITLE
Remove consecutive run commands "Resolves #750."

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -10,8 +10,8 @@ RUN npm install && npm run build
 FROM mcr.microsoft.com/playwright:v1.36.0-jammy as app-stage
 WORKDIR /app
 COPY package*.json .
-RUN npm install --omit=dev
-RUN npx playwright install --with-deps chromium
+RUN npm install --omit=dev && \
+    npx playwright install --with-deps chromium
 COPY --from=build-stage /wikiadviser-backend/dist .
 
 EXPOSE 3000


### PR DESCRIPTION
This pull request consolidates consecutive RUN commands in the Dockerfile into a single instruction to reduce the number of layers in the resulting image, improving build efficiency and performance. By combining the npm install and npx playwright install commands, we ensure environment consistency across steps and minimize unnecessary overhead, resulting in a cleaner and faster build process.

