### PR TITLE
Refactor: Migrate authentication middleware from `Express` to `Hono`.

### DIFF
--- a/supabase/functions/_shared/supabaseClient.ts
+++ b/supabase/functions/_shared/supabaseClient.ts
@@ -8,6 +8,6 @@ export default function createSupabaseClient(authorization = "") {
       global: {
         headers: { Authorization: authorization },
       },
-    }
+    },
   );
 }

--- a/supabase/functions/backend/.npmrc
+++ b/supabase/functions/backend/.npmrc
@@ -1,0 +1,3 @@
+# Configuration for private npm package dependencies
+# For more information on using private registries with Edge Functions, see:
+# https://supabase.com/docs/guides/functions/import-maps#importing-from-private-registries

--- a/supabase/functions/backend/api/mediawiki.ts
+++ b/supabase/functions/backend/api/mediawiki.ts
@@ -1,0 +1,55 @@
+import { fetch } from "undici";
+import { ENV } from "../schema/env.schema.ts";
+// type LanguageCode = (typeof ENV.WIKIADVISER_LANGUAGES)[number]; // Define the language code type
+
+const mediawikiApiInstances = new Map<string, string>();
+for (const language of ENV.WIKIADVISER_LANGUAGES) {
+  mediawikiApiInstances.set(
+    language,
+    `${ENV.MEDIAWIKI_ENDPOINT}/${language}/api.php`,
+  );
+}
+
+/**
+ * Makes a request to the MediaWiki API for a given language.
+ *
+ * @param language The language code (e.g., 'en', 'fr').
+ * @param params An object containing the API parameters.
+ * @returns A promise that resolves to the API response data, or null if an error occurs.
+ */
+export async function makeMediawikiApiRequest(
+  language: string,
+  params: Record<string, string>,
+): Promise<unknown | null> {
+  const baseURL = mediawikiApiInstances.get(language);
+
+  if (!baseURL) {
+    console.error(`Invalid language code: ${language}`);
+    return null;
+  }
+
+  const url = new URL(baseURL);
+  Object.entries(params).forEach(([key, value]) => {
+    url.searchParams.append(key, value);
+  });
+
+  try {
+    const response = await fetch(url.toString(), {
+      dispatcher: new Agent({ connect: { rejectUnauthorized: false } }),
+    });
+
+    if (!response.ok) {
+      console.error(
+        `MediaWiki API request failed with status ${response.status}`,
+      );
+      return null;
+    }
+
+    const data = await response.json();
+    return data;
+  } catch (error) {
+    console.error("Error making MediaWiki API request:", error);
+    return null;
+  }
+}
+import { Agent } from "undici";

--- a/supabase/functions/backend/controllers/auth.controller.ts
+++ b/supabase/functions/backend/controllers/auth.controller.ts
@@ -1,0 +1,102 @@
+import { Context } from "hono";
+import { getArticle, getUserPermission } from "../helper/supabaseHelper.ts";
+import { ENV } from "../schema/env.schema.ts";
+import { SupabaseAuthorization } from "../services/SupabaseResolver.ts";
+
+const wikiadviserLanguagesRegex = ENV.WIKIADVISER_LANGUAGES.join("|");
+const articleIdRegEx = new RegExp(
+  `^/wiki/(${wikiadviserLanguagesRegex})/index.php(\\?title=|/)([0-9a-f-]{36})(&|$|\\?)`,
+  "i",
+);
+export const allowedPrefixRegEx = new RegExp(
+  `^/wiki/(${wikiadviserLanguagesRegex})/(images/thumb|load.php\\?|api.php\\?action=(editcheckreferenceurl|query|templatedata)&format=json&(url|meta=(filerepoinfo|siteinfo)|(formatversion=2&)?(revids=\\d+&prop=mapdata|titles=)|prop=(imageinfo(&indexpageids=1&iiprop=size%7Cmediatype)?|info%7Cpageprops%7Cpageimages%7Cdescription&pithumbsize=80&pilimit=1&ppprop=disambiguation%7Chiddencat)&titles=)|(skins|resources|images/timeline)/|extensions/(UniversalLanguageSelector|Kartographer|wikihiero))`,
+  "i",
+);
+
+/**
+ * Restricts access (HTTP 403) to MediaWiki endpoints based on user permissions and request details.
+ *
+ * @param {Context} c - The Hono context object.
+ */
+export async function restrictMediawikiAccess(
+  c: Context,
+) {
+  const forwardedUri = c.req.header("x-forwarded-uri");
+  const forwardedMethod = c.req.header("x-forwarded-method");
+  const cookieHeader = c.req.header("cookie");
+
+  try {
+    const authHandler = new SupabaseAuthorization();
+    const user = await authHandler.verifyCookie(cookieHeader);
+
+    if (typeof forwardedUri !== "string") {
+      return c.text("You are not authorized to access this content", 403);
+    }
+
+    const articleIdForwardedUri = forwardedUri.match(articleIdRegEx)?.[3];
+
+    const forwardUriAllowedPrefixes = ENV.WIKIADVISER_LANGUAGES.map(
+      (lang: string) => `/wiki/${lang}/api.php`,
+    );
+    const forwardUriStartsWith = ENV.WIKIADVISER_LANGUAGES.map(
+      (lang: string) => `/wiki/${lang}/api.php?`,
+    );
+
+    const hasAllowedPrefixes = (forwardedMethod === "POST" &&
+      forwardUriAllowedPrefixes.some(
+        (prefix: string) => forwardedUri === prefix,
+      )) ||
+      forwardedUri.match(allowedPrefixRegEx);
+
+    if (!hasAllowedPrefixes) {
+      const article = articleIdForwardedUri
+        ? await getArticle(articleIdForwardedUri)
+        : null;
+      const isPublicArticle = article?.web_publication ?? null;
+      if (!user && !isPublicArticle) {
+        return c.text("You are not authorized to access this content", 403);
+      }
+
+      const isRequestFromVisualEditor =
+        forwardUriStartsWith.some((prefix: string) =>
+          forwardedUri.startsWith(prefix)
+        ) && c.req.query("action") === "visualeditor";
+
+      const articleId = isRequestFromVisualEditor
+        ? (c.req.query("page"))
+        : articleIdForwardedUri;
+      if (!articleId) {
+        return c.text(
+          "This user is not authorized to access this content, missing article",
+          403,
+        );
+      }
+
+      const permission = user
+        ? await getUserPermission(articleId, user.id)
+        : null;
+      if (!permission && !isPublicArticle) {
+        return c.text(
+          "This user is not authorized to access this content, missing permission",
+          403,
+        );
+      }
+
+      const isViewArticle = forwardedUri.match(articleIdRegEx)?.[4] === "";
+      const isViewer = permission
+        ? ["viewer", "reviewer"].includes(permission)
+        : isPublicArticle;
+
+      if (isViewer && !isViewArticle) {
+        return c.text(
+          "This user is not authorized to access this content, editor permissions required",
+          403,
+        );
+      }
+    }
+    return c.text("Ok", 200);
+  } catch (error) {
+    console.error("Error in restrictMediawikiAccess: ", error);
+    return c.text("Oops! Something went wrong.", 500);
+  }
+}

--- a/supabase/functions/backend/controllers/wikipedia.ts
+++ b/supabase/functions/backend/controllers/wikipedia.ts
@@ -1,0 +1,29 @@
+import { Context } from "hono";
+import { WikipediaApi } from "../services/WikipediaApi.ts";
+
+/**
+ * Retrieves Wikipedia articles based on the provided search term and language.
+ *
+ * @param {Context} c - The Hono context object.
+ */
+export async function getWikipediaArticle(c: Context) {
+  const term = c.req.query("term");
+  const language = c.req.query("language");
+
+  try {
+    if (typeof term !== "string" || typeof language !== "string") {
+      return c.json({ error: "Type mismatch in query params." }, 400);
+    }
+
+    const wikipediaApi = new WikipediaApi();
+    const response = await wikipediaApi.getWikipediaArticles(term, language);
+
+    return c.json({
+      message: "Getting Wikipedia articles succeeded.",
+      searchResults: response,
+    });
+  } catch (error) {
+    console.error(error);
+    return c.json({ error: "Failed to retrieve Wikipedia articles" }, 500);
+  }
+}

--- a/supabase/functions/backend/deno.json
+++ b/supabase/functions/backend/deno.json
@@ -1,0 +1,25 @@
+{
+  "imports": {
+    "supabase": "jsr:@supabase/supabase-js@2",
+    "md5": "jsr:@takker/md5",
+    "shared/": "../_shared/",
+    "std/": "https://deno.land/std@0.192.0/",
+    "hono": "jsr:@hono/hono@4.7",
+    "cors": "npm:cors@2.8.5",
+    "undici": "npm:undici@7.5.0",
+    "zod": "npm:zod@3.24.2",
+    "cheerio": "https://esm.sh/cheerio@1.0.0-rc.12",
+    "html-entities": "https://esm.sh/html-entities@2.4.0",
+    "@sentry/deno": "https://esm.sh/@sentry/deno@7.76.0"
+  },
+  "compilerOptions": {
+    "lib": ["dom", "esnext", "deno.ns"]
+  },
+  "tasks": {
+    "start": "deno run --allow-net --allow-read --allow-env src/index.ts",
+    "dev": "deno run --allow-net --allow-read --allow-env --watch src/index.ts"
+  },
+  "lock": true
+}
+
+

--- a/supabase/functions/backend/deno.lock
+++ b/supabase/functions/backend/deno.lock
@@ -1,0 +1,303 @@
+{
+  "version": "4",
+  "specifiers": {
+    "jsr:@hono/hono@4.7": "4.7.4",
+    "npm:@supabase/auth-js@2.69.1": "2.69.1",
+    "npm:@supabase/functions-js@2.4.4": "2.4.4",
+    "npm:@supabase/node-fetch@2.6.15": "2.6.15",
+    "npm:@supabase/postgrest-js@1.19.2": "1.19.2",
+    "npm:@supabase/realtime-js@2.11.2": "2.11.2",
+    "npm:@supabase/storage-js@2.7.1": "2.7.1",
+    "npm:@types/node@*": "22.12.0",
+    "npm:openai@^4.52.5": "4.86.2_zod@3.24.2",
+    "npm:undici@7.5.0": "7.5.0",
+    "npm:zod@3.24.2": "3.24.2"
+  },
+  "jsr": {
+    "@hono/hono@4.7.4": {
+      "integrity": "c03c9cbe0fbfc4e51f3fee6502a7903aa4f9ef7c2c98635607b15eee14258825"
+    }
+  },
+  "npm": {
+    "@supabase/auth-js@2.69.1": {
+      "integrity": "sha512-FILtt5WjCNzmReeRLq5wRs3iShwmnWgBvxHfqapC/VoljJl+W8hDAyFmf1NVw3zH+ZjZ05AKxiKxVeb0HNWRMQ==",
+      "dependencies": [
+        "@supabase/node-fetch"
+      ]
+    },
+    "@supabase/functions-js@2.4.4": {
+      "integrity": "sha512-WL2p6r4AXNGwop7iwvul2BvOtuJ1YQy8EbOd0dhG1oN1q8el/BIRSFCFnWAMM/vJJlHWLi4ad22sKbKr9mvjoA==",
+      "dependencies": [
+        "@supabase/node-fetch"
+      ]
+    },
+    "@supabase/node-fetch@2.6.15": {
+      "integrity": "sha512-1ibVeYUacxWYi9i0cf5efil6adJ9WRyZBLivgjs+AUpewx1F3xPi7gLgaASI2SmIQxPoCEjAsLAzKPgMJVgOUQ==",
+      "dependencies": [
+        "whatwg-url"
+      ]
+    },
+    "@supabase/postgrest-js@1.19.2": {
+      "integrity": "sha512-MXRbk4wpwhWl9IN6rIY1mR8uZCCG4MZAEji942ve6nMwIqnBgBnZhZlON6zTTs6fgveMnoCILpZv1+K91jN+ow==",
+      "dependencies": [
+        "@supabase/node-fetch"
+      ]
+    },
+    "@supabase/realtime-js@2.11.2": {
+      "integrity": "sha512-u/XeuL2Y0QEhXSoIPZZwR6wMXgB+RQbJzG9VErA3VghVt7uRfSVsjeqd7m5GhX3JR6dM/WRmLbVR8URpDWG4+w==",
+      "dependencies": [
+        "@supabase/node-fetch",
+        "@types/phoenix",
+        "@types/ws",
+        "ws"
+      ]
+    },
+    "@supabase/storage-js@2.7.1": {
+      "integrity": "sha512-asYHcyDR1fKqrMpytAS1zjyEfvxuOIp1CIXX7ji4lHHcJKqyk+sLl/Vxgm4sN6u8zvuUtae9e4kDxQP2qrwWBA==",
+      "dependencies": [
+        "@supabase/node-fetch"
+      ]
+    },
+    "@types/node-fetch@2.6.12": {
+      "integrity": "sha512-8nneRWKCg3rMtF69nLQJnOYUcbafYeFSjqkw3jCRLsqkWFlHaoQrr5mXmofFGOx3DKn7UfmBMyov8ySvLRVldA==",
+      "dependencies": [
+        "@types/node@22.12.0",
+        "form-data"
+      ]
+    },
+    "@types/node@18.19.84": {
+      "integrity": "sha512-ACYy2HGcZPHxEeWTqowTF7dhXN+JU1o7Gr4b41klnn6pj2LD6rsiGqSZojMdk1Jh2ys3m76ap+ae1vvE4+5+vg==",
+      "dependencies": [
+        "undici-types@5.26.5"
+      ]
+    },
+    "@types/node@22.12.0": {
+      "integrity": "sha512-Fll2FZ1riMjNmlmJOdAyY5pUbkftXslB5DgEzlIuNaiWhXd00FhWxVC/r4yV/4wBb9JfImTu+jiSvXTkJ7F/gA==",
+      "dependencies": [
+        "undici-types@6.20.0"
+      ]
+    },
+    "@types/phoenix@1.6.6": {
+      "integrity": "sha512-PIzZZlEppgrpoT2QgbnDU+MMzuR6BbCjllj0bM70lWoejMeNJAxCchxnv7J3XFkI8MpygtRpzXrIlmWUBclP5A=="
+    },
+    "@types/ws@8.18.0": {
+      "integrity": "sha512-8svvI3hMyvN0kKCJMvTJP/x6Y/EoQbepff882wL+Sn5QsXb3etnamgrJq4isrBxSJj5L2AuXcI0+bgkoAXGUJw==",
+      "dependencies": [
+        "@types/node@22.12.0"
+      ]
+    },
+    "abort-controller@3.0.0": {
+      "integrity": "sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==",
+      "dependencies": [
+        "event-target-shim"
+      ]
+    },
+    "agentkeepalive@4.6.0": {
+      "integrity": "sha512-kja8j7PjmncONqaTsB8fQ+wE2mSU2DJ9D4XKoJ5PFWIdRMa6SLSN1ff4mOr4jCbfRSsxR4keIiySJU0N9T5hIQ==",
+      "dependencies": [
+        "humanize-ms"
+      ]
+    },
+    "asynckit@0.4.0": {
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q=="
+    },
+    "call-bind-apply-helpers@1.0.2": {
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "dependencies": [
+        "es-errors",
+        "function-bind"
+      ]
+    },
+    "combined-stream@1.0.8": {
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "dependencies": [
+        "delayed-stream"
+      ]
+    },
+    "delayed-stream@1.0.0": {
+      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ=="
+    },
+    "dunder-proto@1.0.1": {
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "dependencies": [
+        "call-bind-apply-helpers",
+        "es-errors",
+        "gopd"
+      ]
+    },
+    "es-define-property@1.0.1": {
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g=="
+    },
+    "es-errors@1.3.0": {
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw=="
+    },
+    "es-object-atoms@1.1.1": {
+      "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
+      "dependencies": [
+        "es-errors"
+      ]
+    },
+    "es-set-tostringtag@2.1.0": {
+      "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
+      "dependencies": [
+        "es-errors",
+        "get-intrinsic",
+        "has-tostringtag",
+        "hasown"
+      ]
+    },
+    "event-target-shim@5.0.1": {
+      "integrity": "sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ=="
+    },
+    "form-data-encoder@1.7.2": {
+      "integrity": "sha512-qfqtYan3rxrnCk1VYaA4H+Ms9xdpPqvLZa6xmMgFvhO32x7/3J/ExcTd6qpxM0vH2GdMI+poehyBZvqfMTto8A=="
+    },
+    "form-data@4.0.2": {
+      "integrity": "sha512-hGfm/slu0ZabnNt4oaRZ6uREyfCj6P4fT/n6A1rGV+Z0VdGXjfOhVUpkn6qVQONHGIFwmveGXyDs75+nr6FM8w==",
+      "dependencies": [
+        "asynckit",
+        "combined-stream",
+        "es-set-tostringtag",
+        "mime-types"
+      ]
+    },
+    "formdata-node@4.4.1": {
+      "integrity": "sha512-0iirZp3uVDjVGt9p49aTaqjk84TrglENEDuqfdlZQ1roC9CWlPk6Avf8EEnZNcAqPonwkG35x4n3ww/1THYAeQ==",
+      "dependencies": [
+        "node-domexception",
+        "web-streams-polyfill"
+      ]
+    },
+    "function-bind@1.1.2": {
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA=="
+    },
+    "get-intrinsic@1.3.0": {
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "dependencies": [
+        "call-bind-apply-helpers",
+        "es-define-property",
+        "es-errors",
+        "es-object-atoms",
+        "function-bind",
+        "get-proto",
+        "gopd",
+        "has-symbols",
+        "hasown",
+        "math-intrinsics"
+      ]
+    },
+    "get-proto@1.0.1": {
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "dependencies": [
+        "dunder-proto",
+        "es-object-atoms"
+      ]
+    },
+    "gopd@1.2.0": {
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg=="
+    },
+    "has-symbols@1.1.0": {
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ=="
+    },
+    "has-tostringtag@1.0.2": {
+      "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
+      "dependencies": [
+        "has-symbols"
+      ]
+    },
+    "hasown@2.0.2": {
+      "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
+      "dependencies": [
+        "function-bind"
+      ]
+    },
+    "humanize-ms@1.2.1": {
+      "integrity": "sha512-Fl70vYtsAFb/C06PTS9dZBo7ihau+Tu/DNCk/OyHhea07S+aeMWpFFkUaXRa8fI+ScZbEI8dfSxwY7gxZ9SAVQ==",
+      "dependencies": [
+        "ms"
+      ]
+    },
+    "math-intrinsics@1.1.0": {
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g=="
+    },
+    "mime-db@1.52.0": {
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg=="
+    },
+    "mime-types@2.1.35": {
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "dependencies": [
+        "mime-db"
+      ]
+    },
+    "ms@2.1.3": {
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="
+    },
+    "node-domexception@1.0.0": {
+      "integrity": "sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ=="
+    },
+    "node-fetch@2.7.0": {
+      "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
+      "dependencies": [
+        "whatwg-url"
+      ]
+    },
+    "openai@4.86.2_zod@3.24.2": {
+      "integrity": "sha512-nvYeFjmjdSu6/msld+22JoUlCICNk/lUFpSMmc6KNhpeNLpqL70TqbD/8Vura/tFmYqHKW0trcjgPwUpKSPwaA==",
+      "dependencies": [
+        "@types/node@18.19.84",
+        "@types/node-fetch",
+        "abort-controller",
+        "agentkeepalive",
+        "form-data-encoder",
+        "formdata-node",
+        "node-fetch",
+        "zod"
+      ]
+    },
+    "tr46@0.0.3": {
+      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw=="
+    },
+    "undici-types@5.26.5": {
+      "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA=="
+    },
+    "undici-types@6.20.0": {
+      "integrity": "sha512-Ny6QZ2Nju20vw1SRHe3d9jVu6gJ+4e3+MMpqu7pqE5HT6WsTSlce++GQmK5UXS8mzV8DSYHrQH+Xrf2jVcuKNg=="
+    },
+    "undici@7.5.0": {
+      "integrity": "sha512-NFQG741e8mJ0fLQk90xKxFdaSM7z4+IQpAgsFI36bCDY9Z2+aXXZjVy2uUksMouWfMI9+w5ejOq5zYYTBCQJDQ=="
+    },
+    "web-streams-polyfill@4.0.0-beta.3": {
+      "integrity": "sha512-QW95TCTaHmsYfHDybGMwO5IJIM93I/6vTRk+daHTWFPhwh+C8Cg7j7XyKrwrj8Ib6vYXe0ocYNrmzY4xAAN6ug=="
+    },
+    "webidl-conversions@3.0.1": {
+      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ=="
+    },
+    "whatwg-url@5.0.0": {
+      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+      "dependencies": [
+        "tr46",
+        "webidl-conversions"
+      ]
+    },
+    "ws@8.18.1": {
+      "integrity": "sha512-RKW2aJZMXeMxVpnZ6bck+RswznaxmzdULiBr6KY7XkTnW8uvt0iT9H5DkHUChXrc+uurzwa0rVI16n/Xzjdz1w=="
+    },
+    "zod@3.24.2": {
+      "integrity": "sha512-lY7CDW43ECgW9u1TcT3IoXHflywfVqDYze4waEz812jR/bZ8FHDsl7pFQoSZTz5N+2NqRXs8GBwnAwo3ZNxqhQ=="
+    }
+  },
+  "remote": {
+    "https://esm.sh/@sentry/deno@7.76.0": "4e3c90d6c89e83e748a04778406fb9c1149a29a83e6471a9f0248c3824726696",
+    "https://esm.sh/@sentry/deno@7.76.0/denonext/deno.mjs": "56506a0dc15db675c9590706462b162c7a48909e2ba3a759d9f3fa237f3466a0"
+  },
+  "workspace": {
+    "dependencies": [
+      "jsr:@hono/hono@4.7",
+      "jsr:@supabase/supabase-js@2",
+      "jsr:@takker/md5@*",
+      "npm:cors@2.8.5",
+      "npm:undici@7.5.0",
+      "npm:zod@3.24.2"
+    ]
+  }
+}

--- a/supabase/functions/backend/helper/ParsingHelper.ts
+++ b/supabase/functions/backend/helper/ParsingHelper.ts
@@ -1,0 +1,498 @@
+import { Cheerio, CheerioAPI, Element, load } from "cheerio";
+import { encode } from "html-entities";
+import Parsoid from "../services/mediawikiAPI/ParsoidApi";
+import { Tables, TypeOfEditDictionary } from "../types/index.ts";
+import { getChanges } from "./supabaseHelper.ts";
+
+function addPermissionDataToChanges(
+  changesToInsert: Tables<"changes">[],
+  articleId: string,
+  userId: string,
+) {
+  for (const change of changesToInsert) {
+    if (!change.id) {
+      change.article_id = articleId;
+      change.contributor_id = userId;
+    }
+  }
+}
+
+function unindexUnassignedChanges(
+  changesToUpsert: Tables<"changes">[],
+  changes: Tables<"changes">[],
+) {
+  for (const change of changes) {
+    if (
+      !changesToUpsert.some((changeToUpsert) => changeToUpsert.id === change.id)
+    ) {
+      changesToUpsert.push({
+        index: null,
+        archived: change.archived,
+        hidden: change.hidden,
+        id: change.id,
+        status: change.status,
+        content: change.content,
+        article_id: change.article_id,
+        created_at: change.created_at,
+        description: change.description,
+        type_of_edit: change.type_of_edit,
+        contributor_id: change.contributor_id,
+        revision_id: change.revision_id,
+      });
+    }
+  }
+}
+
+function createStrikethroughText(text: string): string {
+  let result = "";
+  for (let i = 0; i < text.length; i++) {
+    result += text[i] + "\u0336";
+  }
+  return result;
+}
+
+function handleComment(
+  $wrapElement: Cheerio<Element>,
+  elementInnerText: string,
+  descriptionList: string[],
+  $CheerioAPI: CheerioAPI,
+) {
+  const typeOfEdit = "comment-insert";
+  $wrapElement.append($CheerioAPI("<span>").text(elementInnerText));
+  $wrapElement.attr("title", elementInnerText);
+  descriptionList.push(elementInnerText);
+  return typeOfEdit;
+}
+
+function generateOuterMostSelectors(classes: string[]): string {
+  return classes
+    .map((className) => `${className}:not(${className} *)`)
+    .join(", ");
+}
+
+function extractInfoboxes(input: string): string[] {
+  const infoboxes: string[] = [];
+  let count = 0;
+  let start = -1;
+  for (let i = 0; i < input.length; i++) {
+    if (input[i] === "{" && input[i + 1] === "{") {
+      if (count === 0) {
+        start = i;
+      }
+      count++;
+      i++; // skip next '{'
+    } else if (input[i] === "}" && input[i + 1] === "}") {
+      count--;
+      if (count === 0 && start !== -1) {
+        const infobox = input.substring(start, i + 2);
+        if (
+          infobox.startsWith("{{Infobox") || infobox.startsWith("{{Taxobox")
+        ) {
+          infoboxes.push(infobox);
+        }
+        start = -1;
+      }
+      i++;
+    }
+  }
+  return infoboxes;
+}
+
+interface RefineArticleChangesResult {
+  changesToUpsert: Tables<"changes">[];
+  htmlContent: string;
+}
+
+export async function refineArticleChanges(
+  articleId: string,
+  html: string,
+  userId: string,
+  revision_id: string,
+): Promise<RefineArticleChangesResult> {
+  try {
+    const $CheerioAPI = load(html);
+    let changeid = -1;
+
+    const extractDescriptionList = (): string[] => {
+      const descriptionList: string[] = [];
+      const descriptionListItems = $CheerioAPI(".ve-ui-diffElement-sidebar >")
+        .children()
+        .eq(changeid += 1)
+        .children()
+        .children();
+      descriptionListItems.each((_i: number, elem: Element) => {
+        let description = "";
+        $CheerioAPI(elem)
+          .find("del")
+          .replaceWith(function (this: Cheerio<Element>) { // Added type for this
+            return `${createStrikethroughText($CheerioAPI(this).text())} `;
+          });
+
+        $CheerioAPI(elem)
+          .find("li")
+          .each((_ulElemIndex: number, ulElem: Element) => { //Marked ulElemIndex as unused
+            description = description.concat(
+              `- ${$CheerioAPI(ulElem).text()}\n`,
+            );
+          });
+
+        description = description || $CheerioAPI(elem).text();
+        descriptionList.push(description);
+      });
+      return descriptionList;
+    };
+
+    // Cache selectors for performance
+    const diffElements = "[data-diff-action]:not([data-diff-action='none'])";
+    const veCeCommentNode = ".ve-ce-commentNode";
+    // deno-lint-ignore no-unused-vars
+    const descriptionSidebar = ".ve-ui-diffElement-sidebar >";
+    const hasDescriptionsClass = "ve-ui-diffElement-hasDescriptions";
+    // deno-lint-ignore no-unused-vars
+    const diffIdSelector = "[data-diff-id]";
+    // deno-lint-ignore no-unused-vars
+    const parsoidSelector = "[data-parsoid]";
+    const changeContentSelector = "span:first";
+
+    // Loop through elements that have the attribute data-diff-action
+    $CheerioAPI(diffElements).each((_index: number, element: Element) => {
+      const $element = $CheerioAPI(element);
+      const elementInnerText = $element.prop("innerText")?.trim();
+      const tagName = $element.get(0)?.tagName;
+
+      if (!elementInnerText && tagName !== "figure") {
+        // If element is empty of innerText and not a figure, remove it
+        $element.remove();
+        return;
+      }
+
+      const diffAction: string = $element.data("diff-action") as string;
+      let typeOfEdit: string = diffAction;
+      let descriptionList: string[] = []; // Initialize here
+
+      // Pre-extract attributes and content to minimize DOM interaction.
+
+      const isComment = !!$element.find(veCeCommentNode).length;
+      let wrapElementContent: string;
+
+      if (isComment) {
+        typeOfEdit = handleComment(
+          $CheerioAPI("<span>"), // Create a new element instead of using $wrapElement
+          elementInnerText ?? "",
+          descriptionList,
+          $CheerioAPI,
+        );
+        wrapElementContent = `<span>${encode(elementInnerText ?? "")}</span>`;
+      } else {
+        wrapElementContent = $element.clone().toString(); // Get the HTML string
+      }
+
+      // Handle related changes in the next element
+      let nextElementContent = "";
+      const $nextElement = $element.next();
+
+      if ($nextElement.length) {
+        const nextTypeOfEdit = $nextElement.data("diff-action");
+        if (nextTypeOfEdit === "insert" || nextTypeOfEdit === "change-insert") {
+          nextElementContent = $nextElement.clone().toString();
+          wrapElementContent += nextElementContent; // Concatenate directly
+
+          typeOfEdit = nextTypeOfEdit === "insert" ? "remove-insert" : "change";
+          if (nextTypeOfEdit === "change-insert") {
+            descriptionList = extractDescriptionList();
+          }
+          $nextElement.remove(); // Remove next element after processing
+        }
+      }
+
+      if (diffAction === "structural-change") {
+        typeOfEdit = "structural-change";
+        descriptionList = extractDescriptionList();
+      }
+
+      // Construct the wrap element as a string to reduce DOM manipulation
+      const description = descriptionList.join("\n");
+      const wrapElement = `<span data-description="${
+        encode(description)
+      }" data-type-of-edit="${
+        encode(typeOfEdit)
+      }">${wrapElementContent}</span>`;
+
+      // Replace the current element with the constructed wrap element
+      $element.replaceWith(wrapElement);
+    });
+
+    // Remove sidebar and classes (Chained operations can be more efficient)
+    $CheerioAPI(".ve-ui-diffElement-sidebar").remove();
+    $CheerioAPI(".ve-ui-diffElement-hasDescriptions").removeClass(
+      hasDescriptionsClass,
+    );
+
+    const changes = await getChanges(articleId); // Supabase call
+    const changeElements = $CheerioAPI("[data-description]");
+
+    const changesToUpsert: Tables<"changes">[] = [];
+    const changesToInsert: Tables<"changes">[] = [];
+    let changeIndex = 0;
+
+    for (const element of changeElements) {
+      const $element = $CheerioAPI(element);
+      let changeId = "";
+      let description: string | undefined;
+
+      const typeOfEdit = $element.attr("data-type-of-edit") as
+        | "change"
+        | "insert"
+        | "remove"
+        | "remove-insert"
+        | "structural-change"
+        | "comment-insert";
+
+      for (const change of changes) {
+        const $changeContent = load(change.content, null, false);
+        const changeContentInnerHTML = $changeContent(changeContentSelector)
+          .html();
+        if (
+          TypeOfEditDictionary[typeOfEdit] === change.type_of_edit &&
+          $element.html() === changeContentInnerHTML
+        ) {
+          // Update the change INDEX
+          changeId = change.id;
+
+          changesToUpsert.push({
+            id: change.id,
+            archived: change.archived,
+            hidden: change.hidden,
+            index: changeIndex,
+            status: change.status,
+            content: change.content,
+            article_id: change.article_id,
+            created_at: change.created_at,
+            description: change.description,
+            type_of_edit: change.type_of_edit,
+            contributor_id: change.contributor_id,
+            revision_id: change.revision_id,
+          });
+          changeIndex += 1;
+          break;
+        }
+      }
+
+      if (!changeId) {
+        // Create new change
+        description = $element.attr("data-description");
+        $element.removeAttr("data-description");
+        changesToInsert.push({
+          content: $CheerioAPI.html($element),
+          status: 0,
+          description: description as string,
+          type_of_edit: TypeOfEditDictionary[typeOfEdit] as number,
+          index: changeIndex,
+          revision_id,
+        } as Tables<"changes">);
+        changeIndex += 1;
+      }
+
+      // Remove data-description & data-type-of-edit Attributes of the html content (Chained operations)
+      $element.removeAttr("data-description").removeAttr("data-type-of-edit")
+        .attr("data-id", "");
+    }
+
+    unindexUnassignedChanges(changesToUpsert, changes);
+
+    // Add 'article_id', 'contributor_id' properties to changeToinsert
+    if (changesToInsert) {
+      addPermissionDataToChanges(changesToInsert, articleId, userId);
+      changesToUpsert.push(...changesToInsert);
+    }
+
+    const htmlContent = $CheerioAPI.html();
+    return { changesToUpsert, htmlContent };
+  } catch (error) {
+    console.error("Error in refineArticleChanges: ", error);
+    throw error; // Re-throw to be handled by the Hono route
+  }
+}
+
+export async function processExportedArticle(
+  pageContentXML: string,
+  sourceLanguage: string,
+  articleId: string,
+  displayTitle: string,
+  pageContentHTML: string,
+): Promise<string> {
+  try {
+    // Add missing </base> into the file. (Exported files from proxies only)
+    let processedData = pageContentXML.replace(
+      "\n    <generator>",
+      "</base>\n    <generator>",
+    );
+
+    // Rename article
+    processedData = processedData.replace(
+      /<title>(.*?)<\/title>/s,
+      `<title>${articleId}</title>`,
+    );
+
+    // Insert DISPLAYTITLE
+    processedData = processedData.replace(
+      /<\/text>/s,
+      `\n{{DISPLAYTITLE:${displayTitle}}}</text>`,
+    );
+
+    // Externalize article sources to wikipedia
+    const pageStartIndex = processedData.indexOf("<page>");
+    const pageEndIndex = processedData.indexOf("</page>", pageStartIndex);
+    const pageContent = processedData.substring(pageStartIndex, pageEndIndex);
+
+    let updatedPageContent = await parseWikidataTemplate(
+      pageContent,
+      pageContentHTML,
+      articleId,
+      new Parsoid(sourceLanguage),
+    );
+    updatedPageContent = fixSources(updatedPageContent, sourceLanguage);
+
+    processedData = processedData.substring(0, pageStartIndex) +
+      updatedPageContent +
+      processedData.substring(pageEndIndex);
+
+    return processedData;
+  } catch (error) {
+    console.error("Error in processExportedArticle: ", error);
+    throw error; // Re-throw for Hono to handle
+  }
+}
+
+/**
+ * Parses Wikidata template from XML and HTML content of a Wikipedia page.
+ */
+async function parseWikidataTemplate(
+  pageContentXML: string,
+  pageContentHTML: string,
+  articleId: string,
+  parsoidInstance: Parsoid,
+): Promise<string> {
+  try {
+    let newParsedContentXML = pageContentXML;
+    const infoboxClasses = [".infobox", ".infobox_v2", ".infobox_v3"];
+
+    const infoboxesWikitext = extractInfoboxes(newParsedContentXML);
+
+    if (!infoboxesWikitext) {
+      return newParsedContentXML;
+    }
+
+    const $CheerioAPI = load(pageContentHTML);
+    const infoboxesHTML = $CheerioAPI(
+      generateOuterMostSelectors(infoboxClasses),
+    );
+    const isWikidataTemplate = infoboxesHTML
+      .html()
+      ?.toLowerCase()
+      .includes("wikidata");
+
+    if (!isWikidataTemplate) {
+      return newParsedContentXML;
+    }
+
+    infoboxesHTML.find(".wikidata-linkback, .navbar").remove();
+
+    const promises = Array.from(infoboxesHTML).map(async (infobox) => {
+      const infoboxHtml = $CheerioAPI.html(infobox);
+      const wikiText = await parsoidInstance.ParsoidHtmlToWikitext(
+        infoboxHtml,
+        articleId,
+      );
+      const parsedWikitext = wikiText
+        .replace(/<style[^>]*>.*<\/style>/g, "")
+        .replace(/\[\[.*(=|\/)((File|Fichier):(.*?))\]\]/g, "[[$2]]") // Replace image links to wikitext
+        .replace(/(&lang=\w+)/g, "") // Remove '&lang=[value]' from wikipedia links
+        .replace(/\[\[[^\]]*www\.wikidata\.org[^\]]*(?<!File:)\]\]/g, "") // Remove wikidata redundant links
+        .replace(
+          /\|-((?!(\|-))[\s\S])*\[\[\/media\/wikipedia\/commons\/(?!.*File:)[^\]]*?\]\]([\s\S]*?)(?=\n\|)/g,
+          "",
+        ) // Remove wikidata row (modify/icon) 👉 A wikitext table row start with | (if at the beginning) or |- and ends before the next |
+        .replace(/\[\/wiki\/([^ \]]+)\s+([^\]]+)\]/g, "[[$1|$2]]"); // [wiki/article_name] => [[article_name]]
+      return encode(parsedWikitext);
+    });
+
+    const parsedInfoboxes = await Promise.all(promises);
+    for (const infobox of infoboxesWikitext) {
+      if (infobox) {
+        newParsedContentXML = newParsedContentXML.replace(infobox, () => {
+          const escapedInfobox = parsedInfoboxes.shift();
+          if (escapedInfobox === undefined) {
+            throw new Error("Failed to parse all wikidata template");
+          }
+          return escapedInfobox;
+        });
+      }
+    }
+    return newParsedContentXML;
+  } catch (error) {
+    console.error("Error in parseWikidataTemplate: ", error);
+    throw error;
+  }
+}
+
+function fixSources(pageContent: string, sourceLanguage: string): string {
+  let updatedPageContent = addSourceExternalLinks(pageContent, sourceLanguage);
+  updatedPageContent = addSourceTemplate(updatedPageContent, sourceLanguage);
+  updatedPageContent = convertSourceTemplateToLink(
+    updatedPageContent,
+    sourceLanguage,
+  );
+  return updatedPageContent;
+}
+
+function addSourceExternalLinks(
+  pageContent: string,
+  sourceLanguage: string,
+): string {
+  return pageContent.replace(
+    /\[\[(?!(?:File|Fichier))([^|\]]+)(?:\|([^|\]]*))?\]\]/g,
+    (_: string, page: string, preview: string) =>
+      `[[wikipedia:${sourceLanguage}:${page}|${preview || page}]]`,
+  );
+}
+
+function addSourceTemplate(
+  pageContent: string,
+  sourceLanguage: string,
+): string {
+  const pattern =
+    /{{(Main|See also|Article (?:détaillé|général))\|((?:[^|}]+(?:\s*\|\s*[^|}]+)*)+)}}/g;
+
+  return pageContent.replace(
+    pattern,
+    (_: string, templateType: string, articles: string) => {
+      const parsedArticles = articles
+        .split("|")
+        .map((article: string, index: number) => {
+          if (/^l\d+=/.test(article)) {
+            return article.trim();
+          }
+          const label = `l${index + 1}=`;
+          return `wikipedia:${sourceLanguage}:${article.trim()}${
+            articles.includes(label) ? "" : `|${label}${article.trim()}`
+          }`;
+        });
+
+      return `{{${templateType}|${parsedArticles.join("|")}}}`;
+    },
+  );
+}
+
+function convertSourceTemplateToLink(
+  pageContent: string,
+  sourceLanguage: string,
+): string {
+  return pageContent.replace(
+    /{{Lnobr\|([\s\S]*?)}}/gi,
+    (_: string, group: string) =>
+      group.includes("|")
+        ? `[[wikipedia:${sourceLanguage}:${group}]]`
+        : `[[wikipedia:${sourceLanguage}:${group}|${group}]]`,
+  );
+}

--- a/supabase/functions/backend/helper/supabaseHelper.ts
+++ b/supabase/functions/backend/helper/supabaseHelper.ts
@@ -1,0 +1,337 @@
+// backend/src/helper/supabaseHelper.ts
+
+import { createClient } from "supabase";
+import { Database, Enums, Tables } from "../types/index.ts";
+const supabaseUrl = Deno.env.get("SUPABASE_PROJECT_URL")!;
+const supabaseKey = Deno.env.get("SUPABASE_SECRET_PROJECT_TOKEN")!;
+
+const supabase = createClient<Database>(supabaseUrl, supabaseKey, {
+  global: { fetch: fetch },
+});
+
+export async function insertArticle(
+  title: string,
+  userId: string,
+  language: string,
+  description?: string,
+  imported?: boolean,
+): Promise<string> {
+  try {
+    const { data: articlesData, error: articlesError } = await supabase
+      .from("articles")
+      .insert({ title, description, language, imported })
+      .select("id");
+
+    if (articlesError) {
+      console.error("Error inserting article: ", articlesError);
+      throw new Error(`Failed to insert article: ${articlesError.message}`);
+    }
+
+    if (!articlesData || articlesData.length === 0) {
+      throw new Error("Failed to retrieve article ID after insertion.");
+    }
+
+    const articleId = articlesData[0].id;
+
+    const { error: permissionsError } = await supabase
+      .from("permissions")
+      .insert({ role: "owner", user_id: userId, article_id: articleId });
+
+    if (permissionsError) {
+      console.error("Error inserting permission: ", permissionsError);
+      throw new Error(
+        `Failed to insert permission: ${permissionsError.message}`,
+      );
+    }
+
+    return articleId;
+  } catch (error: unknown) {
+    if (error instanceof Error) {
+      console.error("Unexpected error in insertArticle: ", error);
+      throw new Error(`Unexpected error in insertArticle: ${error.message}`);
+    } else {
+      console.error("Unexpected error in insertArticle: ", error);
+      throw new Error(
+        `Unexpected error in insertArticle: An unknown error occurred`,
+      );
+    }
+  }
+}
+
+export async function updateChange(toChange: Tables<"changes">): Promise<void> {
+  try {
+    const { id, ...updateData } = toChange;
+    const { error: changeError } = await supabase
+      .from("changes")
+      .update(updateData)
+      .eq("id", id);
+
+    if (changeError) {
+      console.error("Error updating change: ", changeError);
+      throw new Error(`Failed to update change: ${changeError.message}`);
+    }
+  } catch (error: unknown) {
+    if (error instanceof Error) {
+      console.error("Unexpected error in updateChange: ", error);
+      throw new Error(`Unexpected error in updateChange: ${error.message}`);
+    } else {
+      console.error("Unexpected error in updateChange: ", error);
+      throw new Error(
+        `Unexpected error in updateChange: An unknown error occurred`,
+      );
+    }
+  }
+}
+
+export async function upsertChanges(
+  changesToUpsert: Tables<"changes">[],
+): Promise<void> {
+  try {
+    const { error } = await supabase.from("changes").upsert(changesToUpsert, {
+      defaultToNull: false,
+      onConflict: "id",
+    });
+
+    if (error) {
+      console.error("Error upserting changes: ", error);
+      throw new Error(`Failed to upsert changes: ${error.message}`);
+    }
+  } catch (error: unknown) {
+    if (error instanceof Error) {
+      console.error("Unexpected error in upsertChanges: ", error);
+      throw new Error(`Unexpected error in upsertChanges: ${error.message}`);
+    } else {
+      console.error("Unexpected error in upsertChanges: ", error);
+      throw new Error(
+        `Unexpected error in upsertChanges: An unknown error occurred`,
+      );
+    }
+  }
+}
+
+export async function updateCurrentHtmlContent(
+  articleId: string,
+  current_html_content: string,
+) {
+  try {
+    const { error: articleError } = await supabase
+      .from("articles")
+      .update({ current_html_content })
+      .eq("id", articleId);
+
+    if (articleError) {
+      console.error("Error updating HTML content: ", articleError);
+      throw new Error(`Failed to update HTML content: ${articleError.message}`);
+    }
+  } catch (error: unknown) {
+    if (error instanceof Error) {
+      console.error("Unexpected error in updateCurrentHtmlContent: ", error);
+      throw new Error(
+        `Unexpected error in updateCurrentHtmlContent: ${error.message}`,
+      );
+    } else {
+      console.error("Unexpected error in updateCurrentHtmlContent: ", error);
+      throw new Error(
+        `Unexpected error in updateCurrentHtmlContent: An unknown error occurred`,
+      );
+    }
+  }
+}
+
+export async function getArticle(articleId: string) {
+  try {
+    const { data: articleData, error: articleError } = await supabase
+      .from("articles")
+      .select("*")
+      .eq("id", articleId)
+      .single();
+
+    if (articleError) {
+      console.error("Error getting article: ", articleError);
+      throw new Error(`Failed to get article: ${articleError.message}`);
+    }
+
+    return articleData;
+  } catch (error: unknown) {
+    if (error instanceof Error) {
+      console.error("Unexpected error in getArticle: ", error);
+      throw new Error(`Unexpected error in getArticle: ${error.message}`);
+    } else {
+      console.error("Unexpected error in getArticle: ", error);
+      throw new Error(
+        `Unexpected error in getArticle: An unknown error occurred`,
+      );
+    }
+  }
+}
+
+export async function getChanges(articleId: string) {
+  try {
+    const { data: changesData, error: changesError } = await supabase
+      .from("changes")
+      .select(
+        `
+                id,
+                content,
+                created_at,
+                description,
+                status,
+                type_of_edit,
+                index,
+                article_id,
+                contributor_id,
+                revision_id,
+                archived,
+                hidden,
+                user: profiles(id, email, avatar_url, default_avatar, allowed_articles), 
+                comments(content,created_at, user: profiles(id, email, avatar_url, default_avatar, allowed_articles)),
+                revision: revisions(summary, revid)
+                `,
+      )
+      .order("index")
+      .eq("article_id", articleId);
+
+    if (changesError) {
+      console.error("Error getting changes: ", changesError);
+      throw new Error(`Failed to get changes: ${changesError.message}`);
+    }
+
+    return changesData;
+  } catch (error: unknown) {
+    if (error instanceof Error) {
+      console.error("Unexpected error in getChanges: ", error);
+      throw new Error(`Unexpected error in getChanges: ${error.message}`);
+    } else {
+      console.error("Unexpected error in getChanges: ", error);
+      throw new Error(
+        `Unexpected error in getChanges: An unknown error occurred`,
+      );
+    }
+  }
+}
+
+export async function deleteArticleDB(articleId: string) {
+  try {
+    const { error: supabaseDeleteError } = await supabase
+      .from("articles")
+      .delete()
+      .eq("id", articleId);
+
+    if (supabaseDeleteError) {
+      console.error("Error deleting article: ", supabaseDeleteError);
+      throw new Error(
+        `Failed to delete article: ${supabaseDeleteError.message}`,
+      );
+    }
+  } catch (error: unknown) {
+    if (error instanceof Error) {
+      console.error("Unexpected error in deleteArticleDB: ", error);
+      throw new Error(`Failed to delete article: ${error.message}`);
+    } else {
+      console.error("Unexpected error in deleteArticleDB: ", error);
+      throw new Error(
+        `Unexpected error in deleteArticleDB: An unknown error occurred`,
+      );
+    }
+  }
+}
+
+export async function getUserPermission(
+  articleId: string,
+  userId: string,
+): Promise<Enums<"role"> | null> {
+  try {
+    const { data, error } = await supabase
+      .from("permissions")
+      .select("role")
+      .eq("user_id", userId)
+      .eq("article_id", articleId)
+      .maybeSingle();
+
+    if (error) {
+      console.error("Error getting user permission: ", error);
+      throw new Error(`Failed to get user permission: ${error.message}`);
+    }
+
+    return data?.role || null;
+  } catch (error: unknown) {
+    if (error instanceof Error) {
+      console.error("Unexpected error in getUserPermission: ", error);
+      throw new Error(`Failed to get user permission: ${error.message}`);
+    } else {
+      console.error("Unexpected error in getUserPermission: ", error);
+      throw new Error(
+        `Unexpected error in getUserPermission: An unknown error occurred`,
+      );
+    }
+  }
+}
+
+export async function insertRevision(
+  article_id: string,
+  revid: string,
+  summary: string,
+): Promise<string> {
+  try {
+    const revidNumber = Number(revid);
+
+    if (isNaN(revidNumber)) {
+      throw new Error("Invalid revid: revid must be a number");
+    }
+
+    const { data: revisionsData, error: revisionsError } = await supabase
+      .from("revisions")
+      .insert({ article_id, revid: revidNumber, summary })
+      .select("id");
+
+    if (revisionsError) {
+      console.error("Error inserting revision: ", revisionsError);
+      throw new Error(`Failed to insert revision: ${revisionsError.message}`);
+    }
+
+    if (!revisionsData || revisionsData.length === 0) {
+      throw new Error("Failed to retrieve revision ID after insertion.");
+    }
+
+    const [revision] = revisionsData;
+    return revision.id;
+  } catch (error: unknown) {
+    if (error instanceof Error) {
+      console.error("Unexpected error in insertRevision: ", error);
+      throw new Error(`Failed to insert revision: ${error.message}`);
+    } else {
+      console.error("Unexpected error in insertRevision: ", error);
+      throw new Error(
+        `Unexpected error in insertRevision: An unknown error occurred`,
+      );
+    }
+  }
+}
+
+export async function getUserArticlesCount(userId: string) {
+  try {
+    const { data: articlesData, error: articlesError } = await supabase
+      .from("permissions")
+      .select("id")
+      .eq("user_id", userId);
+
+    if (articlesError) {
+      console.error("Error getting user articles count: ", articlesError);
+      throw new Error(
+        `Failed to get user articles count: ${articlesError.message}`,
+      );
+    }
+
+    return articlesData ? articlesData.length : 0;
+  } catch (error: unknown) {
+    if (error instanceof Error) {
+      console.error("Unexpected error in getUserArticlesCount: ", error);
+      throw new Error(`Failed to get user articles count: ${error.message}`);
+    } else {
+      console.error("Unexpected error in getUserArticlesCount: ", error);
+      throw new Error(
+        `Unexpected error in getUserArticlesCount: An unknown error occurred`,
+      );
+    }
+  }
+}

--- a/supabase/functions/backend/index.ts
+++ b/supabase/functions/backend/index.ts
@@ -1,0 +1,32 @@
+// Follow this setup guide to integrate the Deno language server with your editor:
+// https://deno.land/manual/getting_started/setup_your_environment
+// This enables autocomplete, go to definition, etc.
+
+// Setup type definitions for built-in Supabase Runtime APIs
+import "jsr:@supabase/functions-js/edge-runtime.d.ts"
+
+console.log("Hello from Functions!")
+
+Deno.serve(async (req) => {
+  const { name } = await req.json()
+  const data = {
+    message: `Hello ${name}!`,
+  }
+
+  return new Response(
+    JSON.stringify(data),
+    { headers: { "Content-Type": "application/json" } },
+  )
+})
+
+/* To invoke locally:
+
+  1. Run `supabase start` (see: https://supabase.com/docs/reference/cli/supabase-start)
+  2. Make an HTTP request:
+
+  curl -i --location --request POST 'http://127.0.0.1:54321/functions/v1/backend' \
+    --header 'Authorization: Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZS1kZW1vIiwicm9sZSI6ImFub24iLCJleHAiOjE5ODM4MTI5OTZ9.CRXP1A7WOeoJeXxjNni43kdQwgnWNReilDMblYTn_I0' \
+    --header 'Content-Type: application/json' \
+    --data '{"name":"Functions"}'
+
+*/

--- a/supabase/functions/backend/middleware/Auth.ts
+++ b/supabase/functions/backend/middleware/Auth.ts
@@ -1,0 +1,35 @@
+import { Context, Next } from "hono"; // Import Context and Next
+import { SupabaseAuthorization } from "../services/SupabaseResolver.ts"; // Adjust path
+
+interface CustomUser {
+  id: string;
+  email: string;
+}
+
+/**
+ * Hono middleware for verifying user sessions.
+ */
+async function authorizationMiddleware(c: Context, next: Next) {
+  try {
+    const authHandler = new SupabaseAuthorization(); // Removed logger
+    const user: CustomUser | null =
+      (await authHandler.verifyToken(c.req.header("authorization"))) ??
+        (await authHandler.verifyCookie(c.req.header("cookie")));
+
+    if (!user) {
+      return c.json({ message: "Authorization denied" }, 401);
+    }
+
+    c.set("user", user);
+
+    await next();
+  } catch (error) {
+    console.error("Error in authorizationMiddleware: ", error);
+    return c.json(
+      { error: { message: "Oops! Something went wrong." } },
+      500,
+    );
+  }
+}
+
+export default authorizationMiddleware;

--- a/supabase/functions/backend/middleware/cors.ts
+++ b/supabase/functions/backend/middleware/cors.ts
@@ -1,0 +1,22 @@
+import { cors } from "hono/cors";
+import { ENV } from "../schema/env.schema.ts";
+
+const allowedOrigins = [
+  ENV.WIKIADVISER_FRONTEND_ENDPOINT,
+  ENV.MEDIAWIKI_ENDPOINT,
+];
+
+const corsMiddleware = cors({
+  origin: (origin: string | undefined) => {
+    if (!origin) {
+      return "*"; // Allow all origins if the origin is not present (e.g., for server-side requests)
+    }
+    if (allowedOrigins.includes(origin)) {
+      return origin; // Allow if the origin is in the allowed list
+    }
+    return null; // Reject other origins
+  },
+  credentials: true,
+});
+
+export default corsMiddleware;

--- a/supabase/functions/backend/middleware/errorHandler.ts
+++ b/supabase/functions/backend/middleware/errorHandler.ts
@@ -1,0 +1,29 @@
+import { Context } from "hono";
+import { ErrorResponse } from "../types/index.ts";
+import { ENV } from "../schema/env.schema.ts";
+import * as http from "std/http/http_status.ts";
+
+const { NODE_ENV } = ENV;
+
+export default function errorHandler(
+  error: Error,
+  c: Context,
+) {
+  console.error(error);
+
+  const code: number = c.res.status !== 200 ? c.res.status : 500;
+  c.status(code as http.Status);
+
+  const response: ErrorResponse = {
+    message: error.message,
+  };
+
+  if (NODE_ENV !== "production") {
+    if (error.stack) {
+      response.stack = error.stack;
+    }
+  }
+
+  console.error(error);
+  return c.json({ ...response });
+}

--- a/supabase/functions/backend/middleware/sentry.ts
+++ b/supabase/functions/backend/middleware/sentry.ts
@@ -1,0 +1,11 @@
+import * as Sentry from "@sentry/deno";
+
+export default function initializeSentry(dsn: string, environment?: string) {
+  Sentry.init({
+    dsn: dsn,
+    environment: environment,
+    tracesSampleRate: 1.0,
+  });
+
+  console.info("Sentry integrated to the server ✔️.");
+}

--- a/supabase/functions/backend/routes/auth.routes.ts
+++ b/supabase/functions/backend/routes/auth.routes.ts
@@ -1,0 +1,7 @@
+import { Hono } from "hono";
+import { restrictMediawikiAccess } from "../controllers/auth.controller.ts";
+const authRouter = new Hono();
+
+authRouter.get("/mediawiki", restrictMediawikiAccess);
+
+export default authRouter;

--- a/supabase/functions/backend/routes/wikipedia.ts
+++ b/supabase/functions/backend/routes/wikipedia.ts
@@ -1,0 +1,6 @@
+import { Hono } from "hono";
+import { getWikipediaArticle } from "../controllers/wikipedia.ts";
+
+export function wikipediaRoutes(app: Hono) {
+  app.get("/wikipedia/articles", getWikipediaArticle);
+}

--- a/supabase/functions/backend/schema/env.schema.ts
+++ b/supabase/functions/backend/schema/env.schema.ts
@@ -1,0 +1,110 @@
+import { z } from "zod";
+
+const envSchema = z.object({
+  SUPABASE_PROJECT_URL: z
+    .string({
+      required_error: "😱 You forgot to add a Supabase URL!",
+    })
+    .url(),
+  SUPABASE_SECRET_PROJECT_TOKEN: z
+    .string({
+      required_error: "😱 You forgot to add a Supabase secret token!",
+    })
+    .trim()
+    .min(1),
+  WIKIADVISER_LANGUAGES: z
+    .string({
+      required_error: "😱 You forgot to add a WikiAdviser languages!",
+    })
+    .transform((str: string) => {
+      const regex = /^[a-z]{2,3}(,[a-z]{2,3})*$/g;
+      if (!regex.test(str)) {
+        throw new Error(
+          "😱 WikiAdviser languages format is wrong! (E.g.:= en,fr,ar)",
+        );
+      }
+      return str.split(",");
+    }),
+  WIKIADVISER_API_PORT: z.coerce
+    .number()
+    .positive()
+    .max(65536, "Port should be >= 0 and < 65536")
+    .default(3000),
+  WIKIADVISER_FRONTEND_ENDPOINT: z
+    .string({
+      required_error: "😱 You forgot to add a front-end URL!",
+    })
+    .url(),
+  WIKIPEDIA_PROXY: z
+    .string({
+      required_error: "😱 You forgot to add a Wikipedia proxy URL!",
+    })
+    .url(),
+  MEDIAWIKI_INTERNAL_ENDPOINT: z
+    .string({
+      required_error: "😱 You forgot to add a MediaWiki internal endpoint!",
+    })
+    .url(),
+  MEDIAWIKI_ENDPOINT: z
+    .string({
+      required_error: "😱 You forgot to add a MediaWiki endpoint!",
+    })
+    .url(),
+  MW_ADMIN_USERNAME: z
+    .string({
+      required_error: "😱 You forgot to add a MediaWiki admin username!",
+    })
+    .trim()
+    .min(1),
+  MW_ADMIN_PASSWORD: z
+    .string({
+      required_error: "😱 You forgot to add a MediaWiki admin password!",
+    })
+    .trim()
+    .min(1),
+  MW_BOT_USERNAME: z
+    .string({
+      required_error: "😱 You forgot to add a MediaWiki bot username!",
+    })
+    .min(1),
+  MW_BOT_PASSWORD: z
+    .string({
+      required_error: "😱 You forgot to add a MediaWiki bot password!",
+    })
+    .min(1),
+  SENTRY_DSN: z.string().optional(),
+  SENTRY_ENV_BACKEND: z.string().optional(),
+  NODE_ENV: z.enum(["development", "production", "test"]).default(
+    "development",
+  ),
+});
+
+// Get environment variables from Deno.env.get
+const envVars: Record<string, string | undefined> = {
+  SUPABASE_PROJECT_URL: Deno.env.get("SUPABASE_PROJECT_URL"),
+  SUPABASE_SECRET_PROJECT_TOKEN: Deno.env.get("SUPABASE_SECRET_PROJECT_TOKEN"),
+  WIKIADVISER_LANGUAGES: Deno.env.get("WIKIADVISER_LANGUAGES"),
+  WIKIADVISER_API_PORT: Deno.env.get("WIKIADVISER_API_PORT"),
+  WIKIADVISER_FRONTEND_ENDPOINT: Deno.env.get("WIKIADVISER_FRONTEND_ENDPOINT"),
+  WIKIPEDIA_PROXY: Deno.env.get("WIKIPEDIA_PROXY"),
+  MEDIAWIKI_INTERNAL_ENDPOINT: Deno.env.get("MEDIAWIKI_INTERNAL_ENDPOINT"),
+  MEDIAWIKI_ENDPOINT: Deno.env.get("MEDIAWIKI_ENDPOINT"),
+  MW_ADMIN_USERNAME: Deno.env.get("MW_ADMIN_USERNAME"),
+  MW_ADMIN_PASSWORD: Deno.env.get("MW_ADMIN_PASSWORD"),
+  MW_BOT_USERNAME: Deno.env.get("MW_BOT_USERNAME"),
+  MW_BOT_PASSWORD: Deno.env.get("MW_BOT_PASSWORD"),
+  SENTRY_DSN: Deno.env.get("SENTRY_DSN"),
+  SENTRY_ENV_BACKEND: Deno.env.get("SENTRY_ENV_BACKEND"),
+  NODE_ENV: Deno.env.get("NODE_ENV"),
+};
+
+const envServer = envSchema.safeParse(envVars);
+
+if (!envServer.success) {
+  console.error("Environment variable validation error:");
+  console.error(envServer.error.issues); // Using console.error instead of logger
+  Deno.exit(1); // Using Deno.exit instead of process.exit
+}
+
+// Export the parsed environment variables
+export const ENV = envServer.data;

--- a/supabase/functions/backend/services/AuthResolver
+++ b/supabase/functions/backend/services/AuthResolver
@@ -1,0 +1,4 @@
+export default interface Authorization<T> {
+  verifyCookie?(cookieHeader: string | undefined): Promise<T | null>;
+  verifyToken?(authorizationHeader: string | undefined): Promise<T | null>;
+}

--- a/supabase/functions/backend/services/SupabaseResolver.ts
+++ b/supabase/functions/backend/services/SupabaseResolver.ts
@@ -1,0 +1,89 @@
+import { createClient } from "supabase";
+import Authorization from "./AuthResolver";
+
+interface CustomUser {
+  id: string;
+  email: string;
+}
+
+export class SupabaseAuthorization implements Authorization<CustomUser> {
+  private readonly jwtKey = "sb-auth-token";
+
+  constructor() {
+  }
+
+  async verifyToken(
+    authorizationHeader: string | undefined,
+  ): Promise<CustomUser | null> {
+    if (!authorizationHeader) {
+      return null;
+    }
+
+    const token = authorizationHeader.split(" ")[1]; // Assuming "Bearer <token>" format
+
+    if (!token) {
+      return null;
+    }
+    const supabaseClient = createClient(
+      Deno.env.get("SUPABASE_PROJECT_URL")!,
+      Deno.env.get("SUPABASE_ANON_KEY")!,
+      {
+        global: { fetch: fetch },
+        auth: {
+          persistSession: false,
+        },
+      },
+    );
+    const { data: { user }, error } = await supabaseClient.auth.getUser(token);
+
+    if (error) {
+      console.error("Error verifying token:", error);
+      return null;
+    }
+
+    return user ? { email: user.email!, id: user.id } : null;
+  }
+
+  async verifyCookie(
+    cookieHeader: string | undefined,
+  ): Promise<CustomUser | null> {
+    if (!cookieHeader) {
+      return null;
+    }
+
+    // Parse the cookie header (you might need a cookie parsing library)
+    const cookies: Record<string, string> = {};
+    cookieHeader.split(";").forEach((cookie) => {
+      const parts = cookie.split("=");
+      if (parts.length === 2) {
+        cookies[parts[0].trim()] = parts[1].trim();
+      }
+    });
+
+    const supabaseSession = cookies["sb-xyclcwvzxcjxktqpmvlm-auth-token"]; // Replace with your actual cookie name
+
+    if (!supabaseSession) {
+      return null;
+    }
+    const supabaseClient = createClient(
+      Deno.env.get("SUPABASE_PROJECT_URL")!,
+      Deno.env.get("SUPABASE_ANON_KEY")!,
+      {
+        global: { fetch: fetch },
+        auth: {
+          persistSession: false,
+        },
+      },
+    );
+    const { data: { user }, error } = await supabaseClient.auth.getUser(
+      supabaseSession,
+    );
+
+    if (error) {
+      console.error("Error verifying cookie:", error);
+      return null;
+    }
+
+    return user ? { email: user.email!, id: user.id } : null;
+  }
+}

--- a/supabase/functions/backend/services/WikipediaApi.ts
+++ b/supabase/functions/backend/services/WikipediaApi.ts
@@ -1,0 +1,133 @@
+import { fetch } from "undici";
+import { processExportedArticle } from "../helper/ParsingHelper.ts";
+import { WikipediaSearchResult } from "../types/index.ts";
+import { WikipediaInteractor } from "./WikipediaInteractor.ts";
+import { ENV } from "../schema/env.schema.ts";
+const WIKIPEDIA_PROXY = ENV.WIKIPEDIA_PROXY;
+
+interface WikipediaApiResponse {
+  query?: {
+    pages?: {
+      [key: string]: {
+        title: string;
+        description?: string;
+        thumbnail?: { source: string };
+      };
+    };
+  };
+  parse?: {
+    text: {
+      "*": string;
+    };
+  };
+}
+
+export class WikipediaApi implements WikipediaInteractor {
+  private static searchResultsLimit = 10;
+
+  async getWikipediaArticles(
+    term: string,
+    language: string,
+  ): Promise<WikipediaSearchResult[]> {
+    const url =
+      `${WIKIPEDIA_PROXY}/w/api.php?action=query&format=json&generator=prefixsearch&prop=pageimages|description&ppprop=displaytitle&piprop=thumbnail&pithumbsize=60&pilimit=${WikipediaApi.searchResultsLimit}&gpssearch=${term}&gpsnamespace=0&gpslimit=${WikipediaApi.searchResultsLimit}&origin=*&lang=${language}`;
+
+    try {
+      const response = await fetch(url);
+      if (!response.ok) {
+        throw new Error(`HTTP error! Status: ${response.status}`);
+      }
+
+      const json: unknown = await response.json();
+
+      const data = json as WikipediaApiResponse;
+
+      const wpSearchedArticles = data?.query?.pages;
+      const results: WikipediaSearchResult[] = [];
+
+      if (wpSearchedArticles) {
+        for (const article in wpSearchedArticles) {
+          if (
+            Object.prototype.hasOwnProperty.call(wpSearchedArticles, article) &&
+            !wpSearchedArticles[article].title.includes(":")
+          ) {
+            const currentArticle = wpSearchedArticles[article];
+            const {
+              title,
+              description,
+              thumbnail: { source = "" } = {},
+            } = currentArticle;
+
+            let thumbnailSource = source;
+            if (thumbnailSource.startsWith("/media")) {
+              thumbnailSource = `${WIKIPEDIA_PROXY}${thumbnailSource}`;
+            }
+
+            results.push({
+              title,
+              description,
+              thumbnail: thumbnailSource,
+            });
+          }
+        }
+      }
+      return results;
+    } catch (error) {
+      console.error("Error in getWikipediaArticles:", error);
+      return [];
+    }
+  }
+
+  async getWikipediaHTML(title: string, language: string): Promise<string> {
+    const url =
+      `${WIKIPEDIA_PROXY}/w/api.php?action=parse&format=json&page=${title}&lang=${language}`;
+
+    try {
+      const response = await fetch(url);
+      if (!response.ok) {
+        throw new Error(`HTTP error! Status: ${response.status}`);
+      }
+      const json: unknown = await response.json();
+
+      const data = json as WikipediaApiResponse;
+
+      const htmlString = data?.parse?.text["*"];
+      if (!htmlString) {
+        throw new Error("Could not get article HTML");
+      }
+      return htmlString;
+    } catch (error) {
+      console.error("Error in getWikipediaHTML:", error);
+      return "";
+    }
+  }
+
+  async exportArticleData(
+    title: string,
+    articleId: string,
+    language: string,
+  ): Promise<string> {
+    const url =
+      `${WIKIPEDIA_PROXY}/w/index.php?title=Special:Export&pages=${title}&templates=true&lang=${language}&curonly=true`;
+
+    try {
+      const response = await fetch(url);
+      if (!response.ok) {
+        throw new Error(`HTTP error! Status: ${response.status}`);
+      }
+      let exportData = await response.text();
+
+      exportData = await processExportedArticle(
+        exportData,
+        language,
+        articleId,
+        title,
+        await this.getWikipediaHTML(title, language),
+      );
+      return exportData;
+    } catch (error) {
+      console.error("Error in exportArticleData:", error);
+      throw error;
+    }
+  }
+}

--- a/supabase/functions/backend/services/WikipediaInteractor.ts
+++ b/supabase/functions/backend/services/WikipediaInteractor.ts
@@ -1,0 +1,8 @@
+import { WikipediaSearchResult } from "../types/index.ts";
+
+export interface WikipediaInteractor {
+  getWikipediaArticles(
+    term: string,
+    language?: string,
+  ): Promise<WikipediaSearchResult[]>;
+}

--- a/supabase/functions/backend/types/database.types.ts
+++ b/supabase/functions/backend/types/database.types.ts
@@ -1,0 +1,534 @@
+export type Json =
+  | string
+  | number
+  | boolean
+  | null
+  | { [key: string]: Json | undefined }
+  | Json[];
+
+export type Database = {
+  public: {
+    Tables: {
+      articles: {
+        Row: {
+          created_at: string | null;
+          current_html_content: string | null;
+          description: string | null;
+          id: string;
+          imported: boolean | null;
+          language: string | null;
+          title: string | null;
+          web_publication: boolean;
+        };
+        Insert: {
+          created_at?: string | null;
+          current_html_content?: string | null;
+          description?: string | null;
+          id?: string;
+          imported?: boolean | null;
+          language?: string | null;
+          title?: string | null;
+          web_publication?: boolean;
+        };
+        Update: {
+          created_at?: string | null;
+          current_html_content?: string | null;
+          description?: string | null;
+          id?: string;
+          imported?: boolean | null;
+          language?: string | null;
+          title?: string | null;
+          web_publication?: boolean;
+        };
+        Relationships: [];
+      };
+      changes: {
+        Row: {
+          archived: boolean;
+          article_id: string | null;
+          content: string | null;
+          contributor_id: string | null;
+          created_at: string | null;
+          description: string | null;
+          hidden: boolean | null;
+          id: string;
+          index: number | null;
+          revision_id: string | null;
+          status: number | null;
+          type_of_edit: number | null;
+        };
+        Insert: {
+          archived?: boolean;
+          article_id?: string | null;
+          content?: string | null;
+          contributor_id?: string | null;
+          created_at?: string | null;
+          description?: string | null;
+          hidden?: boolean | null;
+          id?: string;
+          index?: number | null;
+          revision_id?: string | null;
+          status?: number | null;
+          type_of_edit?: number | null;
+        };
+        Update: {
+          archived?: boolean;
+          article_id?: string | null;
+          content?: string | null;
+          contributor_id?: string | null;
+          created_at?: string | null;
+          description?: string | null;
+          hidden?: boolean | null;
+          id?: string;
+          index?: number | null;
+          revision_id?: string | null;
+          status?: number | null;
+          type_of_edit?: number | null;
+        };
+        Relationships: [
+          {
+            foreignKeyName: "changes_article_id_fkey";
+            columns: ["article_id"];
+            isOneToOne: false;
+            referencedRelation: "articles";
+            referencedColumns: ["id"];
+          },
+          {
+            foreignKeyName: "changes_contributor_id_fkey";
+            columns: ["contributor_id"];
+            isOneToOne: false;
+            referencedRelation: "profiles";
+            referencedColumns: ["id"];
+          },
+          {
+            foreignKeyName: "changes_revision_id_fkey";
+            columns: ["revision_id"];
+            isOneToOne: false;
+            referencedRelation: "revisions";
+            referencedColumns: ["id"];
+          },
+        ];
+      };
+      comments: {
+        Row: {
+          article_id: string;
+          change_id: string | null;
+          commenter_id: string | null;
+          content: string | null;
+          created_at: string | null;
+          id: string;
+        };
+        Insert: {
+          article_id: string;
+          change_id?: string | null;
+          commenter_id?: string | null;
+          content?: string | null;
+          created_at?: string | null;
+          id?: string;
+        };
+        Update: {
+          article_id?: string;
+          change_id?: string | null;
+          commenter_id?: string | null;
+          content?: string | null;
+          created_at?: string | null;
+          id?: string;
+        };
+        Relationships: [
+          {
+            foreignKeyName: "comments_change_id_fkey";
+            columns: ["change_id"];
+            isOneToOne: false;
+            referencedRelation: "changes";
+            referencedColumns: ["id"];
+          },
+          {
+            foreignKeyName: "comments_commenter_id_fkey";
+            columns: ["commenter_id"];
+            isOneToOne: false;
+            referencedRelation: "profiles";
+            referencedColumns: ["id"];
+          },
+          {
+            foreignKeyName: "fk_comments_article_id";
+            columns: ["article_id"];
+            isOneToOne: false;
+            referencedRelation: "articles";
+            referencedColumns: ["id"];
+          },
+        ];
+      };
+      permissions: {
+        Row: {
+          article_id: string | null;
+          created_at: string | null;
+          id: string;
+          role: Database["public"]["Enums"]["role"] | null;
+          user_id: string | null;
+        };
+        Insert: {
+          article_id?: string | null;
+          created_at?: string | null;
+          id?: string;
+          role?: Database["public"]["Enums"]["role"] | null;
+          user_id?: string | null;
+        };
+        Update: {
+          article_id?: string | null;
+          created_at?: string | null;
+          id?: string;
+          role?: Database["public"]["Enums"]["role"] | null;
+          user_id?: string | null;
+        };
+        Relationships: [
+          {
+            foreignKeyName: "permissions_article_id_fkey";
+            columns: ["article_id"];
+            isOneToOne: false;
+            referencedRelation: "articles";
+            referencedColumns: ["id"];
+          },
+          {
+            foreignKeyName: "permissions_user_id_fkey";
+            columns: ["user_id"];
+            isOneToOne: false;
+            referencedRelation: "profiles";
+            referencedColumns: ["id"];
+          },
+        ];
+      };
+      profiles: {
+        Row: {
+          allowed_articles: number;
+          avatar_url: string | null;
+          default_avatar: boolean | null;
+          email: string;
+          id: string;
+        };
+        Insert: {
+          allowed_articles: number;
+          avatar_url?: string | null;
+          default_avatar?: boolean | null;
+          email: string;
+          id: string;
+        };
+        Update: {
+          allowed_articles?: number;
+          avatar_url?: string | null;
+          default_avatar?: boolean | null;
+          email?: string;
+          id?: string;
+        };
+        Relationships: [
+          {
+            foreignKeyName: "profiles_id_fkey";
+            columns: ["id"];
+            isOneToOne: true;
+            referencedRelation: "users";
+            referencedColumns: ["id"];
+          },
+          {
+            foreignKeyName: "profiles_id_fkey";
+            columns: ["id"];
+            isOneToOne: true;
+            referencedRelation: "users";
+            referencedColumns: ["id"];
+          },
+        ];
+      };
+      revisions: {
+        Row: {
+          article_id: string | null;
+          created_at: string;
+          id: string;
+          revid: number;
+          summary: string | null;
+        };
+        Insert: {
+          article_id?: string | null;
+          created_at?: string;
+          id?: string;
+          revid: number;
+          summary?: string | null;
+        };
+        Update: {
+          article_id?: string | null;
+          created_at?: string;
+          id?: string;
+          revid?: number;
+          summary?: string | null;
+        };
+        Relationships: [
+          {
+            foreignKeyName: "revisions_article_id_fkey";
+            columns: ["article_id"];
+            isOneToOne: false;
+            referencedRelation: "articles";
+            referencedColumns: ["id"];
+          },
+        ];
+      };
+      share_links: {
+        Row: {
+          article_id: string;
+          expired_at: string | null;
+          id: string;
+        };
+        Insert: {
+          article_id: string;
+          expired_at?: string | null;
+          id?: string;
+        };
+        Update: {
+          article_id?: string;
+          expired_at?: string | null;
+          id?: string;
+        };
+        Relationships: [
+          {
+            foreignKeyName: "share_links_article_id_fkey";
+            columns: ["article_id"];
+            isOneToOne: false;
+            referencedRelation: "articles";
+            referencedColumns: ["id"];
+          },
+        ];
+      };
+    };
+    Views: {
+      users: {
+        Row: {
+          aud: string | null;
+          banned_until: string | null;
+          confirmation_sent_at: string | null;
+          confirmation_token: string | null;
+          confirmed_at: string | null;
+          created_at: string | null;
+          deleted_at: string | null;
+          email: string | null;
+          email_change: string | null;
+          email_change_confirm_status: number | null;
+          email_change_sent_at: string | null;
+          email_change_token_current: string | null;
+          email_change_token_new: string | null;
+          email_confirmed_at: string | null;
+          encrypted_password: string | null;
+          id: string | null;
+          instance_id: string | null;
+          invited_at: string | null;
+          is_sso_user: boolean | null;
+          is_super_admin: boolean | null;
+          last_sign_in_at: string | null;
+          phone: string | null;
+          phone_change: string | null;
+          phone_change_sent_at: string | null;
+          phone_change_token: string | null;
+          phone_confirmed_at: string | null;
+          raw_app_meta_data: Json | null;
+          raw_user_meta_data: Json | null;
+          reauthentication_sent_at: string | null;
+          reauthentication_token: string | null;
+          recovery_sent_at: string | null;
+          recovery_token: string | null;
+          role: string | null;
+          updated_at: string | null;
+        };
+        Insert: {
+          aud?: string | null;
+          banned_until?: string | null;
+          confirmation_sent_at?: string | null;
+          confirmation_token?: string | null;
+          confirmed_at?: string | null;
+          created_at?: string | null;
+          deleted_at?: string | null;
+          email?: string | null;
+          email_change?: string | null;
+          email_change_confirm_status?: number | null;
+          email_change_sent_at?: string | null;
+          email_change_token_current?: string | null;
+          email_change_token_new?: string | null;
+          email_confirmed_at?: string | null;
+          encrypted_password?: string | null;
+          id?: string | null;
+          instance_id?: string | null;
+          invited_at?: string | null;
+          is_sso_user?: boolean | null;
+          is_super_admin?: boolean | null;
+          last_sign_in_at?: string | null;
+          phone?: string | null;
+          phone_change?: string | null;
+          phone_change_sent_at?: string | null;
+          phone_change_token?: string | null;
+          phone_confirmed_at?: string | null;
+          raw_app_meta_data?: Json | null;
+          raw_user_meta_data?: Json | null;
+          reauthentication_sent_at?: string | null;
+          reauthentication_token?: string | null;
+          recovery_sent_at?: string | null;
+          recovery_token?: string | null;
+          role?: string | null;
+          updated_at?: string | null;
+        };
+        Update: {
+          aud?: string | null;
+          banned_until?: string | null;
+          confirmation_sent_at?: string | null;
+          confirmation_token?: string | null;
+          confirmed_at?: string | null;
+          created_at?: string | null;
+          deleted_at?: string | null;
+          email?: string | null;
+          email_change?: string | null;
+          email_change_confirm_status?: number | null;
+          email_change_sent_at?: string | null;
+          email_change_token_current?: string | null;
+          email_change_token_new?: string | null;
+          email_confirmed_at?: string | null;
+          encrypted_password?: string | null;
+          id?: string | null;
+          instance_id?: string | null;
+          invited_at?: string | null;
+          is_sso_user?: boolean | null;
+          is_super_admin?: boolean | null;
+          last_sign_in_at?: string | null;
+          phone?: string | null;
+          phone_change?: string | null;
+          phone_change_sent_at?: string | null;
+          phone_change_token?: string | null;
+          phone_confirmed_at?: string | null;
+          raw_app_meta_data?: Json | null;
+          raw_user_meta_data?: Json | null;
+          reauthentication_sent_at?: string | null;
+          reauthentication_token?: string | null;
+          recovery_sent_at?: string | null;
+          recovery_token?: string | null;
+          role?: string | null;
+          updated_at?: string | null;
+        };
+        Relationships: [];
+      };
+    };
+    Functions: {
+      add_viewer_to_article:
+        | {
+          Args: {
+            token: string;
+          };
+          Returns: string;
+        }
+        | {
+          Args: {
+            user_id: string;
+            token: string;
+          };
+          Returns: string;
+        };
+      delete_user_and_anonymize_data: {
+        Args: Record<PropertyKey, never>;
+        Returns: undefined;
+      };
+      delete_user_and_keep_data: {
+        Args: Record<PropertyKey, never>;
+        Returns: undefined;
+      };
+      is_article_exists: {
+        Args: {
+          article_id: string;
+        };
+        Returns: string;
+      };
+      read_secret: {
+        Args: {
+          secret_name: string;
+        };
+        Returns: string;
+      };
+    };
+    Enums: {
+      role: "owner" | "editor" | "reviewer" | "viewer";
+    };
+    CompositeTypes: {
+      [_ in never]: never;
+    };
+  };
+};
+
+export type Tables<
+  PublicTableNameOrOptions extends
+    | keyof (Database["public"]["Tables"] & Database["public"]["Views"])
+    | { schema: keyof Database },
+  TableName extends PublicTableNameOrOptions extends { schema: keyof Database }
+    ? keyof (
+      & Database[PublicTableNameOrOptions["schema"]]["Tables"]
+      & Database[PublicTableNameOrOptions["schema"]]["Views"]
+    )
+    : never = never,
+> = PublicTableNameOrOptions extends { schema: keyof Database } ? (
+    & Database[PublicTableNameOrOptions["schema"]]["Tables"]
+    & Database[PublicTableNameOrOptions["schema"]]["Views"]
+  )[TableName] extends {
+    Row: infer R;
+  } ? R
+  : never
+  : PublicTableNameOrOptions extends keyof (
+    & Database["public"]["Tables"]
+    & Database["public"]["Views"]
+  ) ? (
+      & Database["public"]["Tables"]
+      & Database["public"]["Views"]
+    )[PublicTableNameOrOptions] extends {
+      Row: infer R;
+    } ? R
+    : never
+  : never;
+
+export type TablesInsert<
+  PublicTableNameOrOptions extends
+    | keyof Database["public"]["Tables"]
+    | { schema: keyof Database },
+  TableName extends PublicTableNameOrOptions extends { schema: keyof Database }
+    ? keyof Database[PublicTableNameOrOptions["schema"]]["Tables"]
+    : never = never,
+> = PublicTableNameOrOptions extends { schema: keyof Database }
+  ? Database[PublicTableNameOrOptions["schema"]]["Tables"][TableName] extends {
+    Insert: infer I;
+  } ? I
+  : never
+  : PublicTableNameOrOptions extends keyof Database["public"]["Tables"]
+    ? Database["public"]["Tables"][PublicTableNameOrOptions] extends {
+      Insert: infer I;
+    } ? I
+    : never
+  : never;
+
+export type TablesUpdate<
+  PublicTableNameOrOptions extends
+    | keyof Database["public"]["Tables"]
+    | { schema: keyof Database },
+  TableName extends PublicTableNameOrOptions extends { schema: keyof Database }
+    ? keyof Database[PublicTableNameOrOptions["schema"]]["Tables"]
+    : never = never,
+> = PublicTableNameOrOptions extends { schema: keyof Database }
+  ? Database[PublicTableNameOrOptions["schema"]]["Tables"][TableName] extends {
+    Update: infer U;
+  } ? U
+  : never
+  : PublicTableNameOrOptions extends keyof Database["public"]["Tables"]
+    ? Database["public"]["Tables"][PublicTableNameOrOptions] extends {
+      Update: infer U;
+    } ? U
+    : never
+  : never;
+
+export type Enums<
+  PublicEnumNameOrOptions extends
+    | keyof Database["public"]["Enums"]
+    | { schema: keyof Database },
+  EnumName extends PublicEnumNameOrOptions extends { schema: keyof Database }
+    ? keyof Database[PublicEnumNameOrOptions["schema"]]["Enums"]
+    : never = never,
+> = PublicEnumNameOrOptions extends { schema: keyof Database }
+  ? Database[PublicEnumNameOrOptions["schema"]]["Enums"][EnumName]
+  : PublicEnumNameOrOptions extends keyof Database["public"]["Enums"]
+    ? Database["public"]["Enums"][PublicEnumNameOrOptions]
+  : never;

--- a/supabase/functions/backend/types/index.ts
+++ b/supabase/functions/backend/types/index.ts
@@ -1,0 +1,40 @@
+export interface Article {
+  current_html_content: string;
+}
+
+export interface ChildNodeData extends ChildNode {
+  data?: string;
+}
+
+export type WikipediaSearchResult = {
+  title: string;
+  description?: string;
+  thumbnail?: string;
+};
+
+export enum TypeOfEditDictionary {
+  change = 0,
+  insert = 1,
+  remove = 2,
+  "structural-change" = 3,
+  "remove-insert" = 4,
+  "comment-insert" = 5,
+}
+
+export interface ErrorResponse {
+  message: string;
+  stack?: string;
+}
+
+export type Account = {
+  [key: string]: string;
+};
+
+export type {
+  Database,
+  Enums,
+  Json,
+  Tables,
+  TablesInsert,
+  TablesUpdate,
+} from "./database.types.ts";


### PR DESCRIPTION
Refactor: Migrate authentication middleware from Express to Hono

This PR adapts the auth middleware for Supabase Edge Functions.
Replaces Express types with Hono's Context, enabling Edge compatibility.
Updates auth services to work in the deno.
Ensures existing auth functionality works in the new environment.