### PR TITLE
Mediawiki 403 fixes

### DIFF
--- a/backend/src/controllers/auth.controller.ts
+++ b/backend/src/controllers/auth.controller.ts
@@ -10,7 +10,7 @@ const articleIdRegEx = new RegExp(
   'i'
 );
 export const allowedPrefixRegEx = new RegExp(
-  `^/wiki/(${wikiadviserLanguagesRegex})/(images/thumb|load.php\\?|api.php\\?action=(editcheckreferenceurl|query|templatedata)&format=json&(url|meta=(filerepoinfo|siteinfo)|(formatversion=2&)?(revids=\\d+&prop=mapdata|titles=)|(formatversion=2&)?prop=(imageinfo(&indexpageids=1&iiprop=size%7Cmediatype|&iiprop=url&iiurlwidth=300&iiurlheight=)?|info%7Cpageprops%7Cpageimages%7Cdescription&pithumbsize=80&pilimit=1&ppprop=disambiguation%7Chiddencat)&titles=)|(skins|resources|images/timeline)/|extensions/(UniversalLanguageSelector|Kartographer|wikihiero))`,
+  `^/wiki/(${wikiadviserLanguagesRegex})/(images/thumb|load.php\\?|api.php\\?action=(editcheckreferenceurl|query|templatedata)&format=json&(formatversion=2&)?(url|meta=(filerepoinfo|siteinfo)|(revids=\\d+&prop=mapdata|titles=)|prop=(imageinfo(&indexpageids=1&iiprop=size%7Cmediatype|&iiprop=url&iiurlwidth=300&iiurlheight=)?|info%7Cpageprops%7Cpageimages%7Cdescription&pithumbsize=80&pilimit=1&ppprop=disambiguation%7Chiddencat)&titles=)|(skins|resources|images/timeline)/|extensions/(UniversalLanguageSelector|Kartographer|wikihiero))`,
   'i'
 );
 


### PR DESCRIPTION
allows links like
- api.php?action=query&format=json&formatversion=2&meta=siteinfo&siprop=interwikimap&maxage=86400&smaxage=86400&uselang=content
- api.php?action=query&format=json&formatversion=2&prop=imageinfo&iiprop=url&iiurlwidth=300&iiurlheight=&titles=File%3AUSA%202007.svg
