### PR TITLE
add `--no-verify-jwt` to the `wikipedia` edge-function deploy script

### DIFF
--- a/.github/workflows/deploy-supabase-functions-prod.yml
+++ b/.github/workflows/deploy-supabase-functions-prod.yml
@@ -38,4 +38,4 @@ jobs:
         run: supabase functions deploy user-avatar --debug
 
       - name: deploy wikipedia
-        run: supabase functions deploy wikipedia --debug
+        run: supabase functions deploy wikipedia --no-verify-jwt --debug

--- a/.github/workflows/deploy-supabase-functions-qa.yml
+++ b/.github/workflows/deploy-supabase-functions-qa.yml
@@ -38,4 +38,4 @@ jobs:
         run: supabase functions deploy user-avatar --debug
 
       - name: deploy wikipedia
-        run: supabase functions deploy wikipedia --debug
+        run: supabase functions deploy wikipedia --no-verify-jwt --debug


### PR DESCRIPTION
resolves `{"code":401,"message":"Missing authorization header"}`
related to #813 