### PR TITLE
Fix mediawiki setup script

### DIFF
--- a/mediawiki-setup/mediawiki-setup.sh
+++ b/mediawiki-setup/mediawiki-setup.sh
@@ -117,7 +117,7 @@ if [[ "$1" == "--upgrade" ]]; then
     echo "Backing up old MediaWiki folders"
     for ln in "${LANGUAGES[@]}"; do
         if [[ -d "/var/www/${MW_PROJECT_DIR}/wiki/$ln" ]]; then
-            mv "/var/www/${MW_PROJECT_DIR}/wiki/$ln" "/var/www/${MW_PROJECT_DIR}/wiki/$ln-$(date +%Y%m%d-%H%M%S)"
+            mv "/var/www/${MW_PROJECT_DIR}/wiki/$ln" "/var/www/${MW_PROJECT_DIR}/wiki/$ln.old"
         fi
     done
 


### PR DESCRIPTION
- Fix path declaration
- Fix backup folders naming to avoid overriding old dumps
- Fix `envsubst` failing to write output due to permissions (Using `tee` instead with sudo privilege) 
- Fix wildcard (*) not working inside quotes
- Remove unnecessary color styling
- Fix switching path without falling back to original path (where the script exists)
- Fix: Run database update after adding extensions and LocalSettings.php
