### PR TITLE
feat: create importArticle function and edit route for frontend

### DIFF
--- a/frontend/src/api/supabaseHelper.ts
+++ b/frontend/src/api/supabaseHelper.ts
@@ -64,13 +64,20 @@ export async function importArticle(
   language: wikiadviserLanguage,
   description?: string,
 ) {
-  const response = await api.post('article/import', {
-    title,
-    userId,
-    language,
-    description,
-  });
-  return response.data.articleId;
+  const { data, error } = await supabaseClient.functions.invoke(
+    'article/import',
+    {
+      method: 'POST',
+      body: {
+        title,
+        userId,
+        language,
+        description,
+      },
+    },
+  );
+  if (error) throw new Error(error.message);
+  return data.articleId;
 }
 
 export async function getArticles(userId: string): Promise<Article[]> {

--- a/supabase/functions/_shared/helpers/parsingHelper.ts
+++ b/supabase/functions/_shared/helpers/parsingHelper.ts
@@ -1,0 +1,192 @@
+import { load } from "npm:cheerio@1.0.0";
+import Parsoid from "../mediawikiAPI/ParasoidApi.ts";
+import { encode } from "npm:html-entities@2.6.0";
+function fixSources(pageContent: string, sourceLanguage: string) {
+  let updatedPageContent = addSourceExternalLinks(pageContent, sourceLanguage);
+  updatedPageContent = addSourceTemplate(updatedPageContent, sourceLanguage);
+  updatedPageContent = convertSourceTemplateToLink(
+    updatedPageContent,
+    sourceLanguage,
+  );
+  return updatedPageContent;
+}
+export function addSourceExternalLinks(
+  pageContent: string,
+  sourceLanguage: string,
+) {
+  return pageContent.replace(
+    /\[\[(?!(?:File|Fichier))([^|\]]+)(?:\|([^|\]]*))?\]\]/g,
+    (_, page, preview) =>
+      `[[wikipedia:${sourceLanguage}:${page}|${preview || page}]]`,
+  );
+}
+export function convertSourceTemplateToLink(
+  pageContent: string,
+  sourceLanguage: string,
+) {
+  return pageContent.replace(
+    /{{Lnobr\|([\s\S]*?)}}/gi,
+    (_, group) =>
+      group.includes("|")
+        ? `[[wikipedia:${sourceLanguage}:${group}]]`
+        : `[[wikipedia:${sourceLanguage}:${group}|${group}]]`,
+  );
+}
+export function addSourceTemplate(pageContent: string, sourceLanguage: string) {
+  const pattern =
+    /{{(Main|See also|Article (?:détaillé|général))\|((?:[^|}]+(?:\s*\|\s*[^|}]+)*)+)}}/g;
+
+  return pageContent.replace(pattern, (_, templateType, articles) => {
+    const parsedArticles = articles
+      .split("|")
+      .map((article: string, index: number) => {
+        if (/^l\d+=/.test(article)) {
+          return article.trim();
+        }
+        const label = `l${index + 1}=`;
+        return `wikipedia:${sourceLanguage}:${article.trim()}${
+          articles.includes(label) ? "" : `|${label}${article.trim()}`
+        }`;
+      });
+
+    return `{{${templateType}|${parsedArticles.join("|")}}}`;
+  });
+}
+function generateOuterMostSelectors(classes: string[]) {
+  return classes
+    .map((className) => `${className}:not(${className} *)`)
+    .join(", ");
+}
+function extractInfoboxes(input: string) {
+  const infoboxes = [];
+  let count = 0;
+  let start = -1;
+  for (let i = 0; i < input.length; i += 1) {
+    if (input[i] === "{" && input[i + 1] === "{") {
+      if (count === 0) {
+        start = i;
+      }
+      count += 1;
+      i += 1; // skip next '{'
+    } else if (input[i] === "}" && input[i + 1] === "}") {
+      count -= 1;
+      if (count === 0 && start !== -1) {
+        const infobox = input.substring(start, i + 2);
+        if (
+          infobox.startsWith("{{Infobox") ||
+          infobox.startsWith("{{Taxobox")
+        ) {
+          infoboxes.push(infobox);
+        }
+        start = -1;
+      }
+      i += 1; // skip next '}'
+    }
+  }
+  return infoboxes;
+}
+async function parseWikidataTemplate(
+  pageContentXML: string,
+  pageContentHTML: string,
+  articleId: string,
+  parsoidInstance: Parsoid,
+): Promise<string> {
+  let newParsedContentXML = pageContentXML;
+  const infoboxClasses = [".infobox", ".infobox_v2", ".infobox_v3"];
+
+  const infoboxesWikitext = extractInfoboxes(newParsedContentXML);
+
+  if (!infoboxesWikitext) {
+    return newParsedContentXML;
+  }
+
+  const $CheerioAPI = load(pageContentHTML);
+  const infoboxesHTML = $CheerioAPI(generateOuterMostSelectors(infoboxClasses));
+  const isWikidataTemplate = infoboxesHTML
+    .html()
+    ?.toLowerCase()
+    .includes("wikidata");
+
+  if (!isWikidataTemplate) {
+    return newParsedContentXML;
+  }
+
+  infoboxesHTML.find(".wikidata-linkback, .navbar").remove();
+
+  const promises = Array.from(infoboxesHTML).map(async (infobox) => {
+    const infoboxHtml = $CheerioAPI.html(infobox);
+    const wikiText = await parsoidInstance.ParsoidHtmlToWikitext(
+      infoboxHtml,
+      articleId,
+    );
+    const parsedWikitext = wikiText
+      .replace(/<style[^>]*>.*<\/style>/g, "")
+      .replace(/\[\[.*(=|\/)((File|Fichier):(.*?))\]\]/g, "[[$2]]") // Replace image links to wikitext
+      .replace(/(&lang=\w+)/g, "") // Remove '&lang=[value]' from wikipedia links
+      .replace(/\[\[[^\]]*www\.wikidata\.org[^\]]*(?<!File:)\]\]/g, "") // Remove wikidata redundant links
+      .replace(
+        /\|-((?!(\|-))[\s\S])*\[\[\/media\/wikipedia\/commons\/(?!.*File:)[^\]]*?\]\]([\s\S]*?)(?=\n\|)/g,
+        "",
+      ) // Remove wikidata row (modify/icon) 👉 A wikitext table row start with | (if at the beginning) or |- and ends before the next |
+      .replace(/\[\/wiki\/([^ \]]+)\s+([^\]]+)\]/g, "[[$1|$2]]"); // [wiki/article_name] => [[article_name]]
+    return encode(parsedWikitext);
+  });
+
+  const parsedInfoboxes = await Promise.all(promises);
+  for (const infobox of infoboxesWikitext) {
+    if (infobox) {
+      newParsedContentXML = newParsedContentXML.replace(infobox, () => {
+        const escapedInfobox = parsedInfoboxes.shift();
+        if (escapedInfobox === undefined) {
+          throw new Error("Failed to parse all wikidata template");
+        }
+        return escapedInfobox;
+      });
+    }
+  }
+  return newParsedContentXML;
+}
+export async function processExportedArticle(
+  pageContentXML: string,
+  sourceLanguage: string,
+  articleId: string,
+  displayTitle: string,
+  pageContentHTML: string,
+): Promise<string> {
+  // Add missing </base> into the file. (Exported files from proxies only)
+  let processedData = pageContentXML.replace(
+    "\n    <generator>",
+    "</base>\n    <generator>",
+  );
+
+  // Rename article
+  processedData = processedData.replace(
+    /<title>(.*?)<\/title>/s,
+    `<title>${articleId}</title>`,
+  );
+
+  // Insert DISPLAYTITLE
+  processedData = processedData.replace(
+    /<\/text>/s,
+    `\n{{DISPLAYTITLE:${displayTitle}}}</text>`,
+  );
+
+  // Externalize article sources to wikipedia
+  const pageStartIndex = processedData.indexOf("<page>");
+  const pageEndIndex = processedData.indexOf("</page>", pageStartIndex);
+  const pageContent = processedData.substring(pageStartIndex, pageEndIndex);
+
+  let updatedPageContent = await parseWikidataTemplate(
+    pageContent,
+    pageContentHTML,
+    articleId,
+    new Parsoid(sourceLanguage),
+  );
+  updatedPageContent = fixSources(updatedPageContent, sourceLanguage);
+
+  processedData = processedData.substring(0, pageStartIndex) +
+    updatedPageContent +
+    processedData.substring(pageEndIndex);
+
+  return processedData;
+}

--- a/supabase/functions/_shared/mediawikiAPI/ParasoidApi.ts
+++ b/supabase/functions/_shared/mediawikiAPI/ParasoidApi.ts
@@ -1,0 +1,74 @@
+import axios, { AxiosInstance } from "axios";
+import mediawikiApiInstances from "./mediawikiApiInstances.ts";
+
+export default class Parsoid {
+  private readonly parsoidBaseAPI: AxiosInstance;
+
+  /**
+   * Constructs the Parsoid class instance.
+   *
+   * @param language - The language for which to build the Parsoid API.
+   * @throws Error if no MediaWiki instance is found for the given language.
+   */
+  constructor(language: string) {
+    this.parsoidBaseAPI = Parsoid.buildParsoidApi(language);
+  }
+
+  /**
+   * Builds the Parsoid API based on the provided language.
+   *
+   * @param language - The language for which to build the Parsoid API.
+   * @returns The constructed AxiosInstance for the Parsoid API.
+   * @throws Error if no MediaWiki instance is found for the given language.
+   */
+  private static buildParsoidApi(language: string): AxiosInstance {
+    const mediawikiApiInstance = mediawikiApiInstances.get(language);
+
+    if (!mediawikiApiInstance) {
+      throw new Error(`No MediaWiki instance found for language ${language}`);
+    }
+
+    const mediawikiBaseURL = mediawikiApiInstance.getUri();
+    const domain = new URL(mediawikiBaseURL).hostname;
+
+    return axios.create({
+      baseURL: `https://${domain}/wiki/${language}/rest.php/${domain}`,
+      headers: {
+        "Content-Type": "application/json",
+      },
+    });
+  }
+
+  /**
+   * Converts HTML content to Wikitext using the Parsoid API.
+   *
+   * @param html - The HTML content to convert.
+   * @param articleId - The ID of the article.
+   * @returns The converted Wikitext.
+   */
+  async ParsoidHtmlToWikitext(
+    html: string,
+    articleId: string,
+  ): Promise<string> {
+    try {
+      const response = await this.parsoidBaseAPI.post(
+        `/v3/transform/html/to/wikitext/${articleId}`,
+        { html },
+        {
+          headers: {
+            "Content-Type": "application/json",
+          },
+        },
+      );
+
+      if (response.status !== 200) {
+        const error = response.data.error ??
+          `Error converting HTML to Wikitext: ${response.statusText}`;
+        throw new Error(error);
+      }
+      return response.data;
+    } catch (error) {
+      throw new Error(`Error converting HTML to Wikitext: ${error}`);
+    }
+  }
+}

--- a/supabase/functions/_shared/mediawikiAPI/mediawikiApiInstances.ts
+++ b/supabase/functions/_shared/mediawikiAPI/mediawikiApiInstances.ts
@@ -1,6 +1,6 @@
 import axios, { AxiosInstance } from "axios";
 import https from "node:https";
-import ENV from "../_shared/schema/env.schema.ts";
+import ENV from "../schema/env.schema.ts";
 
 const mediawikiApiInstances = new Map<
   (typeof ENV.WIKIADVISER_LANGUAGES)[number],

--- a/supabase/functions/_shared/wikipedia/WikipediaApi.ts
+++ b/supabase/functions/_shared/wikipedia/WikipediaApi.ts
@@ -1,5 +1,5 @@
 import axios, { AxiosInstance } from "axios";
-//import { processExportedArticle } from '../../helpers/parsingHelper';
+import { processExportedArticle } from "../helpers/parsingHelper.ts";
 import { WikipediaSearchResult } from "../types/index.ts";
 import WikipediaInteractor from "./WikipediaInteractor.ts";
 import ENV from "../schema/env.schema.ts";
@@ -84,44 +84,44 @@ export class WikipediaApi implements WikipediaInteractor {
     return htmlString;
   }
 
-  /*async exportArticleData(
+  async exportArticleData(
     title: string,
     articleId: string,
-    language: string
+    language: string,
   ): Promise<string> {
     const exportResponse = await axios.get(`${this.wpProxy}/w/index.php`, {
       params: {
-        title: 'Special:Export',
+        title: "Special:Export",
         pages: title,
         templates: true,
         lang: language,
-        curonly: true
+        curonly: true,
       },
-      responseType: 'stream'
+      responseType: "stream",
     });
 
     return new Promise<string>((resolve, reject) => {
-      let exportData = '';
-      exportResponse.data.on('data', (chunk: string) => {
+      let exportData = "";
+      exportResponse.data.on("data", (chunk: string) => {
         exportData += chunk;
       });
 
-      exportResponse.data.on('end', async () => {
+      exportResponse.data.on("end", async () => {
         exportData = await processExportedArticle(
           exportData,
           language,
           articleId,
           title,
-          await this.getWikipediaHTML(title, language)
+          await this.getWikipediaHTML(title, language),
         );
         resolve(exportData);
       });
 
-      exportResponse.data.on('error', (error: Error) => {
+      exportResponse.data.on("error", (error: Error) => {
         reject(error);
       });
     });
-  }*/
+  }
 }
 
 const wikipediaApi = new WikipediaApi();

--- a/supabase/functions/article/deno.json
+++ b/supabase/functions/article/deno.json
@@ -1,6 +1,9 @@
 {
   "imports": {
+    "cheerio": "npm:cheerio@^1.0.0",
+    "form-data": "npm:form-data@^4.0.2",
     "hono": "npm:hono@4.7.4",
+    "html-entities": "npm:html-entities@^2.6.0",
     "zod": "npm:zod@3.24.2",
     "supabase": "https://esm.sh/@supabase/supabase-js@2",
     "supabase-ssr": "npm:@supabase/ssr@0.6.1",

--- a/supabase/functions/article/importArticle.ts
+++ b/supabase/functions/article/importArticle.ts
@@ -1,0 +1,71 @@
+import { Context } from "hono";
+import corsHeaders from "../_shared/cors.ts";
+import {
+  deleteArticleDB,
+  getUserArticlesCount,
+  insertArticle,
+} from "../_shared/helpers/supabaseHelper.ts";
+import createSupabaseClient from "../_shared/supabaseClient.ts";
+import wikipediaApi from "../_shared/wikipedia/WikipediaApi.ts";
+import MediawikiClient from "./MediawikiClient.ts";
+
+export async function importArticle(context: Context) {
+  const { title, language, description } = await context.req.json();
+  let articleId = null;
+  const supabaseClient = createSupabaseClient(
+    context.req.header("Authorization"),
+  );
+
+  const {
+    data: { user },
+  } = await supabaseClient.auth.getUser();
+
+  if (!user) {
+    return new Response("Unauthorized", {
+      headers: corsHeaders,
+      status: 401,
+    });
+  }
+
+  try {
+    const totalUserArticles = await getUserArticlesCount(user.id);
+    const { allowed_articles: allowedArticles } = (
+      await supabaseClient
+        .from("profiles")
+        .select("*")
+        .eq("id", user.id)
+        .single()
+    ).data;
+
+    if (totalUserArticles >= allowedArticles) {
+      return context.json(
+        { message: "You have reached the maximum number of articles allowed." },
+        402,
+      );
+    }
+
+    articleId = await insertArticle(
+      title,
+      user.id,
+      language,
+      description,
+      true,
+    );
+
+    const mediawiki = new MediawikiClient(language, wikipediaApi);
+    await mediawiki.importArticle(articleId, title);
+
+    return context.json({
+      message: "Importing new article succeeded.",
+      articleId,
+    }, 201);
+  } catch (error) {
+    if (articleId) {
+      await deleteArticleDB(articleId);
+    }
+    return context.json({
+      message: "An error occurred while processing your request",
+      error: error instanceof Error ? error.message : String(error),
+    }, 500);
+  }
+}

--- a/supabase/functions/article/index.ts
+++ b/supabase/functions/article/index.ts
@@ -3,6 +3,7 @@ import corsHeaders from "../_shared/cors.ts";
 import { createArticle } from "./createArticle.controller.ts";
 import { deleteArticle } from "./deleteArticle.ts";
 import { hasPermissions } from "./hasPermission.ts";
+import { importArticle } from "./importArticle.ts";
 
 const functionName = "article";
 const app = new Hono().basePath(`/${functionName}`);
@@ -19,6 +20,7 @@ app.use("*", async (c, next) => {
 });
 
 app.post("/", createArticle);
+app.post("/import", importArticle);
 app.delete("/:id", hasPermissions(["owner"]), deleteArticle);
 
 Deno.serve(app.fetch);


### PR DESCRIPTION
Description: This pull request introduces the importArticle function, which allows authenticated users to import an article using the Mediawiki API. Key updates include:

Implemented importArticle logic to:

Check user quota from Supabase (allowed_articles)

Create a new article record

Use MediawikiClient to import the content

Roll back if import fails

Added a route in the Edge Function to expose the import endpoint (POST /import-article) for frontend consumption

Ensured proper error handling and consistent response structure

This feature will enable users to programmatically create and populate articles through the frontend UI.