### PR TITLE
fix addSourceTemplate pattern

### DIFF
--- a/backend/src/helpers/parsingHelper.ts
+++ b/backend/src/helpers/parsingHelper.ts
@@ -397,8 +397,7 @@ export function addSourceExternalLinks(
  * @returns The updated page content with modified templates.
  */
 export function addSourceTemplate(pageContent: string, sourceLanguage: string) {
-  const pattern =
-    /{{(Main|See also|Article (?:détaillé|général))\|((?:[^|}]+(?:\s*\|\s*[^|}]+)*)+)}}/g;
+  const pattern = /{{(Main|See also|Article (?:détaillé|général))\|([^}]+?)}}/g;
 
   return pageContent.replace(pattern, (_, templateType, articles) => {
     const parsedArticles = articles


### PR DESCRIPTION
- fix #831 

the problem was with the part `|}}` which caused a catastrophic backtracking in
```
{{See also|Exhaust gas|Waste tires|Environmental effects of transport|Externalities of automobiles|Noise pollution|Environmental aspects of the electric car|Vehicle recycling|}}
```