### PR TITLE
refactor: streamline CORS middleware and remove global preflight handler

### DIFF
--- a/supabase/functions/_shared/cors.ts
+++ b/supabase/functions/_shared/cors.ts
@@ -8,11 +8,15 @@ export const corsHeaders = {
 };
 
 export const corsMiddleware: MiddlewareHandler = async (c, next) => {
-  await next();
-
-  // Attach CORS headers to the final response
-  const res = c.res;
+  // Set CORS headers before handling the request
   for (const [key, value] of Object.entries(corsHeaders)) {
-    res.headers.set(key, value);
+    c.res.headers.set(key, value);
   }
+
+  // Handle OPTIONS preflight request
+  if (c.req.method === "OPTIONS") {
+    return new Response(null, { headers: c.res.headers });
+  }
+
+  await next();
 };

--- a/supabase/functions/wikipedia/index.ts
+++ b/supabase/functions/wikipedia/index.ts
@@ -1,5 +1,5 @@
 import { Hono } from "hono";
-import { corsHeaders, corsMiddleware } from "../_shared/cors.ts";
+import { corsMiddleware } from "../_shared/cors.ts";
 import getWikipediaArticle from "./controller.ts";
 
 const functionName = "wikipedia";
@@ -9,12 +9,4 @@ app.use("*", corsMiddleware);
 
 app.get("/articles", getWikipediaArticle);
 
-Deno.serve((req) => {
-  // Global CORS preflight handler
-  if (req.method === "OPTIONS") {
-    return new Response("ok", { headers: corsHeaders });
-  }
-
-  // Let Hono handle everything else
-  return app.fetch(req);
-});
+Deno.serve(app.fetch);


### PR DESCRIPTION
there is error in app-qa:
`blocked by CORS policy: Response to preflight request doesn't pass access control check: It does not have HTTP ok status.Understand this error` ,I try to fix it by setting CORS headers before handling the request then handle OPTIONS preflight request.