### PR TITLE
MediaWiki: avoid forcing the first letter of links to capitals

### DIFF
--- a/mediawiki-setup/LocalSettings.php
+++ b/mediawiki-setup/LocalSettings.php
@@ -338,5 +338,5 @@ $wgForeignFileRepos[] = [
 wfLoadExtension( 'WikiEditor' );
 $wgWikiEditorRealtimePreview = true;
 
-# to avoid forcing the first letter of links to capitals
+# To avoid forcing the first letter of links to capitals
 $wgCapitalLinks = false;


### PR DESCRIPTION
- fix #866 

https://www.mediawiki.org/wiki/Manual:$wgCapitalLinks

Later we should run the [cleanupCaps.php](https://www.mediawiki.org/wiki/Special:MyLanguage/Manual:cleanupCaps.php) maintenance script to fix the existing links that will be broken.