### PR TITLE
edge function: use `deno_version`'s default value `1`

### DIFF
--- a/supabase/config.toml
+++ b/supabase/config.toml
@@ -283,7 +283,7 @@ policy = "oneshot"
 # Port to attach the Chrome inspector for debugging edge functions.
 inspector_port = 8083
 # The Deno major version to use.
-deno_version = 2
+deno_version = 1
 
 # [edge_runtime.secrets]
 # secret_key = "env(SECRET_VALUE)"


### PR DESCRIPTION
might resolve #905 