### PR TITLE
migrate "hide non editor distractions" to common.js

### DIFF
--- a/mediawiki-docker/MEDIAWIKI_SETUP.md
+++ b/mediawiki-docker/MEDIAWIKI_SETUP.md
@@ -220,6 +220,18 @@
               });
           }
       };
+
+      mw.hook('ve.activationStart').add(function () {
+        try {
+          // Make inner page full width and hide left bar (TOC)
+          var elements = document.querySelectorAll('.mw-page-container-inner, .mw-body');
+          for (var i = 0; i < elements.length; i++) {
+            elements[i].removeAttribute('class');
+          }
+        } catch (error) {
+          console.error('An error occurred while trying to hide non-editor distractions', error.message);
+        }
+      });
       ```
 
       </details>

--- a/mediawiki-docker/resources/extensions/MyVisualEditor/modules/ve-mw/preinit/ve.init.mw.ProgressBarWidget.js
+++ b/mediawiki-docker/resources/extensions/MyVisualEditor/modules/ve-mw/preinit/ve.init.mw.ProgressBarWidget.js
@@ -30,15 +30,6 @@ mw.libs.ve.ProgressBarWidget = function VeUiMwProgressBarWidget() {
 	// Stylesheets might not have processed yet, so manually set starting width to 0
 	this.$bar = $( '<div>' ).addClass( 've-init-mw-progressBarWidget-bar' ).css( 'width', 0 );
 	this.$element = $( '<div>' ).addClass( 've-init-mw-progressBarWidget' ).append( this.$bar );
-
-	/* Custom WikiAdviser */
-	try {
-		// Make inner page full width and hide left bar (TOC)
-		document.querySelectorAll('.mw-page-container-inner, .mw-body')?.forEach((element) => {element?.removeAttribute('class')});
-		} catch (error) {
-		console.error('An error occurred while trying to hide non editor distractions', error.message);
-		}
-	/* End WikiAdviser */
 };
 
 mw.libs.ve.ProgressBarWidget.prototype.setLoadingProgress = function ( target, duration ) {


### PR DESCRIPTION
"hide non editor distractions" using  common.js instead of editing VisualEditor

- resolves #931 