### PR TITLE
migrate 'On "Save Changes" go to diffUrl' to common.js

### DIFF
--- a/mediawiki-docker/MEDIAWIKI_SETUP.md
+++ b/mediawiki-docker/MEDIAWIKI_SETUP.md
@@ -232,6 +232,33 @@
           console.error('An error occurred while trying to hide non-editor distractions', error.message);
         }
       });
+
+      // On "Save Changes", go to diffUrl
+      mw.hook('ve.activationComplete').add(function () {
+        const originalSaveComplete =
+          ve.init.mw.ArticleTarget.prototype.saveComplete;
+        ve.init.mw.ArticleTarget.prototype.saveComplete = function (data) {
+          originalSaveComplete.apply(this, arguments);
+
+          const articleId = this.getPageName();
+          window.parent.postMessage(
+            {
+              type: 'saved-changes',
+              articleId: articleId,
+            },
+            '*'
+          );
+          mw.wikiadviser
+            .getDiffUrl(articleId)
+            .then(function (diffUrl) {
+              console.log('Redirecting to diff:', diffUrl);
+              window.location.replace(diffUrl);
+            })
+            .catch(function (error) {
+              console.error('Failed to redirect to diff:', error);
+            });
+        };
+      });
       ```
 
       </details>

--- a/mediawiki-docker/resources/extensions/MyVisualEditor/modules/ve-mw/init/targets/ve.init.mw.ArticleTarget.js
+++ b/mediawiki-docker/resources/extensions/MyVisualEditor/modules/ve-mw/init/targets/ve.init.mw.ArticleTarget.js
@@ -753,25 +753,6 @@ ve.init.mw.ArticleTarget.prototype.saveComplete = function ( data ) {
 		// Not passing trackMechanism because this isn't an abort action
 		this.tryTeardown( true );
 	}
-	/* Custom WikiAdviser */
-	// On "Save Changes", go to diffUrl
-	const articleId = this.getPageName();
-	window.parent.postMessage(
-		{
-			type: 'saved-changes',
-			articleId: articleId,
-		},
-		'*'
-		);
-	mw.wikiadviser.getDiffUrl(articleId)
-		.then(function(diffUrl) {
-			console.log('Redirecting to diff:', diffUrl);
-			window.location.replace(diffUrl);
-		})
-		.catch(function(error) {
-			console.error('Failed to redirect to diff:', error);
-		});
-	/* End WikiAdviser */
 };
 
 /**


### PR DESCRIPTION
migrate On "Save Changes", go to diffUrl from MyVisualEditor to common.js by extending the `ve.init.mw.ArticleTarget.prototype.saveComplete`  function

- resolves partially #931 