### PR TITLE
Fix notifications crashing edge functions due to missing vault value

### DIFF
--- a/supabase/seed.sql
+++ b/supabase/seed.sql
@@ -13,3 +13,8 @@ WHERE NOT EXISTS (
   SELECT 1 FROM auth.users WHERE email = 'deleted-user@wikiadviser.io'
 );
 
+select vault.create_secret(
+  'http://host.docker.internal:54321',
+  'supabase_project_url',
+  'URL to be used for calling edge functions. This is set here to support development with database-triggered webhooks across environments.'
+);


### PR DESCRIPTION
- fix #974
- the importation is triggering a notification, the notification uses vault and crashes

<img width="307" height="84" alt="image" src="https://github.com/user-attachments/assets/98824928-dd45-4db1-a633-b3271c4d0faf" />

@TejBenamor The owner should not recieve a notification about himself creating an article