### PR TITLE
fix invalid WIKIPEDIA_PROXY (QA/PROD)

### DIFF
--- a/supabase/functions/_shared/schema/env.schema.ts
+++ b/supabase/functions/_shared/schema/env.schema.ts
@@ -28,10 +28,9 @@ const envSchema = z.object({
       return str.split(",");
     }),
   WIKIPEDIA_PROXY: z
-    .string({
-      required_error: "😱 You forgot to add a Wikipedia proxy URL!",
-    })
-    .url().optional(),
+    .string()
+    .url({ message: "😱 Invalid Wikipedia proxy URL!" })
+    .optional(),
   MEDIAWIKI_ENDPOINT: z
     .string({
       required_error: "😱 You forgot to add a MediaWiki endpoint!",
@@ -58,7 +57,7 @@ const envSchema = z.object({
 const envServer = envSchema.safeParse({
   WIKIADVISER_LANGUAGES: Deno.env.get("WIKIADVISER_LANGUAGES"),
   WIKIADVISER_BACKGROUND_COLORS: Deno.env.get("WIKIADVISER_BACKGROUND_COLORS"),
-  WIKIPEDIA_PROXY: Deno.env.get("WIKIPEDIA_PROXY"),
+  WIKIPEDIA_PROXY: Deno.env.get("WIKIPEDIA_PROXY") || undefined,
   MEDIAWIKI_ENDPOINT: Deno.env.get("MEDIAWIKI_ENDPOINT"),
   MW_BOT_USERNAME: Deno.env.get("MW_BOT_USERNAME"),
   MW_BOT_PASSWORD: Deno.env.get("MW_BOT_PASSWORD"),


### PR DESCRIPTION
It was because in GitHub Actions, if the variable isn’t defined, it comes through as an empty string `""`, not `undefined`, while Zod's `optional()` just handles `undefined`

<img width="935" height="118" alt="image" src="https://github.com/user-attachments/assets/210c3c74-a451-4602-b3ee-778759dc36d8" />

<img width="711" height="508" alt="image" src="https://github.com/user-attachments/assets/9547f42e-4160-4dcd-82c1-ffe7891f0059" />
