### PR TITLE
Update foreign key constraints in notifications table for cascade delete

### DIFF
--- a/supabase/migrations/20250815113100_fix_delete_on_cascade_notification.sql
+++ b/supabase/migrations/20250815113100_fix_delete_on_cascade_notification.sql
@@ -1,0 +1,17 @@
+ALTER TABLE notifications
+DROP CONSTRAINT notifications_triggered_by_fkey;
+
+ALTER TABLE notifications
+ADD CONSTRAINT notifications_triggered_by_fkey
+FOREIGN KEY (triggered_by)
+REFERENCES profiles(id)
+ON DELETE CASCADE;
+
+ALTER TABLE notifications
+DROP CONSTRAINT IF EXISTS notifications_triggered_on_fkey;
+
+ALTER TABLE notifications
+ADD CONSTRAINT notifications_triggered_on_fkey
+FOREIGN KEY (triggered_on)
+REFERENCES profiles(id)
+ON DELETE CASCADE;


### PR DESCRIPTION
Modify foreign key constraints in the notifications table to enable cascade delete functionality when referenced profiles are deleted.