### PR TITLE
Fix Authorization denied to public articles

### DIFF
--- a/supabase/functions/restrict-mediawiki-access/index.ts
+++ b/supabase/functions/restrict-mediawiki-access/index.ts
@@ -1,10 +1,9 @@
 import { Hono } from "hono";
-import authorizationMiddleware from "../_shared/middleware/auth.ts";
 import restrictMediawikiAccess from "./controller.ts";
 
 const functionName = "restrict-mediawiki-access";
 const app = new Hono().basePath(`/${functionName}`);
 
-app.get("/", authorizationMiddleware, restrictMediawikiAccess);
+app.get("/", restrictMediawikiAccess);
 
 Deno.serve(app.fetch);


### PR DESCRIPTION
- fix #1149 
restrict-mediawiki-access: remove auth middleware, because supabase user authentification is checked as necessary inside `restrictMediawikiAccess()`