### PR TITLE
Fix blank screen due to stale auth cookies for non-existent users

### DIFF
--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -33,6 +33,12 @@ onMounted(async () => {
   await userStore.getSession();
   await userStore.fetchProfile();
 
+  if (userStore.session && !userStore.user) {
+    await supabaseClient.auth.signOut();
+    router.push('/auth');
+    return;
+  }
+
   if (userStore.session) {
     if (!userStore.user?.avatar_url) {
       await supabaseClient.functions.invoke('user/avatar', { method: 'POST' });


### PR DESCRIPTION
Implement a check to sign out users with stale authentication cookies when their profile no longer exists, preventing a blank screen issue.

### Solution
- Detect invalid or missing user/session on app bootstrap
- Automatically Sign out user.
- Redirect user to login page.

resolves #1099