### PR TITLE
Hide profile picture title for anonymous users in settings

### DIFF
--- a/frontend/src/pages/auth/UserAccountPage.vue
+++ b/frontend/src/pages/auth/UserAccountPage.vue
@@ -162,7 +162,12 @@
 
       <!-- Profile Picture Section -->
       <div class="q-my-lg">
-        <h2 class="text-h6 merriweather q-mb-xs">Profile Picture</h2>
+        <h2
+          v-if="hasPassword && hasEmailProvider"
+          class="text-h6 merriweather q-mb-xs"
+        >
+          Profile Picture
+        </h2>
         <div>
           <img
             :src="picture"


### PR DESCRIPTION
Remove the profile picture title for users without a password or email provider to enhance the user experience for anonymous users.
resolves #1230