### PR TITLE
Speed up Processing changes diff generation

### DIFF
--- a/frontend/src/components/MwVisualEditor.vue
+++ b/frontend/src/components/MwVisualEditor.vue
@@ -145,6 +145,11 @@ async function EventHandler(event: MessageEvent): Promise<void> {
       await handleIgnoredInitialEdit();
       break;
     case 'saved-changes':
+      isProcessingChanges.value = true;
+      loading.value = { ...loaderPresets.changes };
+      // The MediaWiki iframe already navigates to the diff view after save.
+      // Avoid double diff navigation (and duplicated API calls) from the parent.
+      break;
     case 'deleted-revision':
       isProcessingChanges.value = true;
       loading.value = { ...loaderPresets.changes };

--- a/supabase/functions/_shared/middleware/supabaseUserAuthorization.ts
+++ b/supabase/functions/_shared/middleware/supabaseUserAuthorization.ts
@@ -38,6 +38,17 @@ class SupabaseAuthorization {
   }
 
   async verifyCookie(context: Context) {
+    // Fast-path: if there are no Supabase session cookies, avoid a network call.
+    const cookieObj = getCookie(context);
+    const cookieKeys = cookieObj ? Object.keys(cookieObj) : [];
+    const supabaseCookieKeys = cookieKeys.filter((key) =>
+      key.startsWith("sb-") || key.toLowerCase().includes("supabase")
+    );
+
+    if (!cookieObj || supabaseCookieKeys.length === 0) {
+      return null;
+    }
+
     const supabaseUrl =
       Deno.env.get("SUPABASE_URL") ?? Deno.env.get("SUPABASE_PROJECT_URL");
     const supabaseAnonKey = Deno.env.get("SUPABASE_ANON_KEY");
@@ -55,6 +66,18 @@ class SupabaseAuthorization {
     }
 
     try {
+      // Cache session verification briefly to avoid repeated calls during bursts
+      // (e.g. MediaWiki assets fetched through forward_auth).
+      const cacheKey = supabaseCookieKeys
+        .sort()
+        .map((k) => `${k}=${cookieObj[k]}`)
+        .join(";");
+      const now = Date.now();
+      const cached = sessionCache.get(cacheKey);
+      if (cached && cached.exp > now) {
+        return cached.user;
+      }
+
       const supabase = createServerClient(supabaseUrl, supabaseAnonKey, {
         cookies: {
           getAll() {
@@ -99,7 +122,9 @@ class SupabaseAuthorization {
         return null;
       }
 
-      return data?.session?.user ?? null;
+      const user = data?.session?.user ?? null;
+      sessionCache.set(cacheKey, { user, exp: now + SESSION_CACHE_TTL_MS });
+      return user;
     } catch (e) {
       console.error(
         "Exception during cookie verification/session retrieval:",
@@ -109,5 +134,8 @@ class SupabaseAuthorization {
     }
   }
 }
+
+const SESSION_CACHE_TTL_MS = 10_000;
+const sessionCache = new Map<string, { user: unknown; exp: number }>();
 
 export default SupabaseAuthorization;

--- a/supabase/functions/restrict-mediawiki-access/controller.ts
+++ b/supabase/functions/restrict-mediawiki-access/controller.ts
@@ -8,6 +8,39 @@ import ENV from "../_shared/schema/env.schema.ts";
 
 import { allowedPrefixRegEx, articleIdRegEx } from "./regex.ts";
 
+const UUID_REGEXP =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+function safeParseForwardedUrl(forwardedUri: string): URL | null {
+  try {
+    return new URL(forwardedUri, "http://local");
+  } catch {
+    return null;
+  }
+}
+
+function extractUuidCandidate(value: string | null): string | null {
+  if (!value) return null;
+  const first = value.split("|")[0];
+  return UUID_REGEXP.test(first) ? first : null;
+}
+
+function isBareArticleView(forwardedUrl: URL, articleId: string): boolean {
+  if (!/^\/wiki\/[a-z]{2,3}\/index\.php$/i.test(forwardedUrl.pathname)) {
+    return false;
+  }
+
+  if (forwardedUrl.searchParams.get("title") !== articleId) {
+    return false;
+  }
+
+  // Only allow the simple view URL for viewer/reviewer/public access.
+  for (const key of forwardedUrl.searchParams.keys()) {
+    if (key !== "title") return false;
+  }
+  return true;
+}
+
 /**
  * Restricts access (HTTP 403) to MediaWiki endpoints based on user permissions and request details.
  *
@@ -18,79 +51,96 @@ export default async function restrictMediawikiAccess(context: Context) {
   const forwardedMethod = context.req.header("x-forwarded-method");
 
   try {
-    const authHandler = new SupabaseAuthorization();
-    const user = await authHandler.verifyCookie(context);
-
     if (typeof forwardedUri !== "string") {
       return new Response("You are not authorized to access this content", {
         status: 403,
       });
     }
 
-    const articleIdForwardedUri = forwardedUri.match(articleIdRegEx)?.[3] ||
-      context.req.query("titles") as string; // Extract articleId from diff urls too
-
+    // IMPORTANT: compute allowlisted paths before any auth/session calls.
+    // This endpoint is used by Caddy forward_auth and can be called many times
+    // while MediaWiki loads assets (load.php/resources/images...).
     const forwardUriAllowedPrefixes = ENV.WIKIADVISER_LANGUAGES.map(
       (lang: string) => `/wiki/${lang}/api.php`,
     );
-    const forwardUriStartsWith = ENV.WIKIADVISER_LANGUAGES.map(
-      (lang: string) => `/wiki/${lang}/api.php?`,
-    );
 
     const hasAllowedPrefixes = (forwardedMethod === "POST" &&
-      forwardUriAllowedPrefixes.some(
-        (prefix: string) => forwardedUri === prefix,
-      )) ||
+        forwardUriAllowedPrefixes.some(
+          (prefix: string) => forwardedUri === prefix,
+        )) ||
       forwardedUri.match(allowedPrefixRegEx);
 
-    if (!hasAllowedPrefixes) {
-      const article = articleIdForwardedUri
-        ? await getArticle(articleIdForwardedUri)
-        : null;
-      const isPublicArticle = article?.web_publication ?? null;
-      if (!user && !isPublicArticle) {
-        return new Response("You are not authorized to access this content", {
-          status: 403,
-        });
-      }
+    if (hasAllowedPrefixes) {
+      return new Response(null, { status: 200 });
+    }
 
-      const isRequestFromVisualEditor =
-        forwardUriStartsWith.some((prefix: string) =>
-          forwardedUri.startsWith(prefix)
-        ) && context.req.query("action") === "visualeditor";
+    const forwardedUrl = safeParseForwardedUrl(forwardedUri);
+    const forwardedSearchParams = forwardedUrl?.searchParams;
 
-      const articleId = isRequestFromVisualEditor
-        ? (context.req.query("page") as string)
-        : articleIdForwardedUri;
-      if (!articleId) {
-        return new Response(
-          "This user is not authorized to access this content, missing article",
-          { status: 403 },
-        );
-      }
+    const articleIdFromIndexPhp = forwardedUri.match(articleIdRegEx)?.[3] ??
+      null;
+    const articleIdFromQuery = extractUuidCandidate(
+      forwardedSearchParams?.get("title") ??
+        forwardedSearchParams?.get("page") ??
+        forwardedSearchParams?.get("titles") ??
+        null,
+    );
 
-      const permission = user
-        ? await getUserPermission(articleId, user.id)
-        : null;
-      if (!permission && !isPublicArticle) {
-        return new Response(
-          "This user is not authorized to access this content, missing permission",
-          { status: 403 },
-        );
-      }
+    const articleId = articleIdFromIndexPhp || articleIdFromQuery;
+    const article = articleId ? await getArticle(articleId) : null;
+    const isPublicArticle = article?.web_publication ?? null;
 
-      const isViewArticle = forwardedUri.match(articleIdRegEx)?.[4] === "";
-      const isViewer = permission
-        ? ["viewer", "reviewer"].includes(permission)
-        : isPublicArticle;
+    // Allow public access for the bare view URL without a session.
+    if (
+      isPublicArticle &&
+      forwardedUrl &&
+      typeof articleId === "string" &&
+      isBareArticleView(forwardedUrl, articleId)
+    ) {
+      return new Response(null, { status: 200 });
+    }
 
-      if (isViewer && !isViewArticle) {
+    const authHandler = new SupabaseAuthorization();
+    const user = await authHandler.verifyCookie(context);
+
+    if (!user && !isPublicArticle) {
+      return new Response("You are not authorized to access this content", {
+        status: 403,
+      });
+    }
+
+    if (!articleId) {
+      return new Response(
+        "This user is not authorized to access this content, missing article",
+        { status: 403 },
+      );
+    }
+
+    const permission = user
+      ? await getUserPermission(articleId, user.id)
+      : null;
+    if (!permission && !isPublicArticle) {
+      return new Response(
+        "This user is not authorized to access this content, missing permission",
+        { status: 403 },
+      );
+    }
+
+    const isViewer = permission
+      ? ["viewer", "reviewer"].includes(permission)
+      : isPublicArticle;
+
+    if (isViewer) {
+      const canView =
+        forwardedUrl ? isBareArticleView(forwardedUrl, articleId) : false;
+      if (!canView) {
         return new Response(
           "This user is not authorized to access this content, editor permissions required",
           { status: 403 },
         );
       }
     }
+
     return new Response(null, { status: 200 });
   } catch (error) {
     console.error(error);


### PR DESCRIPTION
## What/Why
The app shows **Processing changes** while waiting for the MediaWiki iframe to generate the visual diff and send `diff-change` back to the parent.

In demo/prod, MediaWiki pages (including the diff view) trigger many asset requests through Caddy `forward_auth`. Our `restrict-mediawiki-access` function was doing a Supabase session lookup **before** checking the allowlist, so every asset request paid the session round-trip cost.

This PR:
- Returns early for allowlisted `/wiki/*` paths **before** running session verification.
- Adds a short in-memory cache + no-cookie fast-path in `verifyCookie()` to reduce repeated session lookups during request bursts.
- Avoids double diff navigation after save (the iframe already redirects to diff in `Common.js`).

## Changes
- `supabase/functions/restrict-mediawiki-access/controller.ts`: compute allowlist first, parse forwarded URL safely, and only verify session/permissions when needed.
- `supabase/functions/_shared/middleware/supabaseUserAuthorization.ts`: fast-path when no Supabase cookies; cache session verification for 10s.
- `frontend/src/components/MwVisualEditor.vue`: on `saved-changes`, stop posting an extra "go to diff" command (prevents duplicated redirects/API calls).

## How to verify
1. Open an article, make a small edit, click **Save changes**.
2. In DevTools:
   - Observe fewer/cheaper calls to `/functions/v1/restrict-mediawiki-access` during diff load (should no longer cause a Supabase auth round-trip for allowlisted assets).
   - Ensure `saved-changes` still leads to `diff-change`, and the spinner clears as usual.