### PR TITLE
preserve prompts when updating llm_reviewer_config

### DIFF
--- a/frontend/src/pages/auth/UserAccountPage.vue
+++ b/frontend/src/pages/auth/UserAccountPage.vue
@@ -606,10 +606,24 @@ async function updateLLMConfigInDB(updates: {
   const userId = userStore.user?.id;
   if (!userId) return;
 
+  const { data: profileData } = await supabaseClient
+    .from('profiles')
+    .select('llm_reviewer_config')
+    .eq('id', userId)
+    .single();
+
+  const existingConfig =
+    typeof profileData?.llm_reviewer_config === 'object' &&
+    profileData?.llm_reviewer_config !== null &&
+    !Array.isArray(profileData?.llm_reviewer_config)
+      ? (profileData.llm_reviewer_config as Record<string, unknown>)
+      : {};
+
   const { error } = await supabaseClient
     .from('profiles')
     .update({
       llm_reviewer_config: {
+        ...existingConfig,
         model: updates.model ?? llmConfig.value.model,
         has_api_key: updates.has_api_key ?? apiKey.value.hasPersonalKey,
       },


### PR DESCRIPTION
This PR fixes an issue where updating the LLM model in `userAccountPage.vue `was unintentionally overwriting the entire `llm_reviewer_config object in the profiles table.

Previously, when the `model` or `API key` status was updated, the existing configuration — including stored prompts and selected_prompt_id — was being lost because the whole object was replaced.

This change:

Fetches the existing `llm_reviewer_config` before performing the update

Merges the existing configuration using the spread operator

Updates only the intended fields (`model` and `has_api_key`)

This ensures that changing the model no longer removes saved prompts or other configuration fields.

resolves #1249
