### PR TITLE
prevent duplicate diff-change API calls on saved-changes

### DIFF
--- a/frontend/src/components/MwVisualEditor.vue
+++ b/frontend/src/components/MwVisualEditor.vue
@@ -148,7 +148,6 @@ async function EventHandler(event: MessageEvent): Promise<void> {
       isProcessingChanges.value = true;
       loading.value = { ...loaderPresets.changes };
       // The MediaWiki iframe already navigates to the diff view after save.
-      // Avoid double diff navigation (and duplicated API calls) from the parent.
       break;
     case 'deleted-revision':
       isProcessingChanges.value = true;


### PR DESCRIPTION
Split the two cases. saved-changes now only sets the loading state and lets MediaWiki's native post-save navigation trigger diff-change naturally.