### PR TITLE
resolve infinite recursion error when saving prompts

### DIFF
--- a/supabase/migrations/20260220102155_secure_profiles.sql
+++ b/supabase/migrations/20260220102155_secure_profiles.sql
@@ -1,9 +1,7 @@
 drop policy "Public profiles are viewable by everyone."
 on "public"."profiles";
 
-alter policy "Enable users to view their own data only"
+create policy "Enable users to view their own data only"
 on "public"."profiles"
 to authenticated
-using (
-	(( SELECT auth.uid() AS uid) = id)
-);
+using ( auth.uid() = id );


### PR DESCRIPTION
### Problem
Saving a prompt caused: "infinite recursion detected in policy for relation 'profiles'"
so the UPDATE policy "Users can update own profile." had an EXISTS subquery that queried the profiles table, triggering RLS recursively.
### Solution
Simplified the policy to use just `auth.uid() = id`, which is sufficient since each user can only modify their own row.

resolves #1262 