### PR TITLE
fix llm config prompt be deleted after reload

### DIFF
--- a/frontend/src/components/ReviewByMira.vue
+++ b/frontend/src/components/ReviewByMira.vue
@@ -247,7 +247,7 @@ async function savePromptsToDB() {
       .update({
         llm_reviewer_config: {
           ...existingConfig,
-          prompt: customPrompts,
+          prompts: customPrompts,
           selected_prompt_id: selectedPrompt.value?.id || null,
         },
       })


### PR DESCRIPTION
change variable name from `prompt` to `prompts`