### PR TITLE
fix(aiService): add retry logic for openrouter/auto cold-start failures

### DIFF
--- a/supabase/functions/ai-review/services/aiService.ts
+++ b/supabase/functions/ai-review/services/aiService.ts
@@ -4,44 +4,62 @@ export async function reviewArticleSection(
   systemPrompt: string,
   userPrompt: string,
 ): Promise<string> {
-  const response = await fetch(
-    'https://openrouter.ai/api/v1/chat/completions',
-    {
-      method: 'POST',
-      headers: {
-        Authorization: `Bearer ${apiKey}`,
-        'Content-Type': 'application/json',
-      },
-      body: JSON.stringify({
-        model,
-        messages: [
-          { role: 'system', content: systemPrompt },
-          { role: 'user', content: userPrompt },
-        ],
-        temperature: 0.2,
-      }),
-    },
-  );
+  const MAX_RETRIES = 3;
+  let lastError: Error = new Error('Unknown error');
 
-  if (!response.ok) {
-    const errorText = await response.text();
-    console.error('AI API request failed', {
-      status: response.status,
-      error: errorText,
-    });
-    throw new Error(`AI API error ${response.status}: ${errorText}`);
+  for (let attempt = 1; attempt <= MAX_RETRIES; attempt++) {
+    console.log(`AI request attempt ${attempt}/${MAX_RETRIES}...`);
+    try {
+      const response = await fetch(
+        'https://openrouter.ai/api/v1/chat/completions',
+        {
+          method: 'POST',
+          headers: {
+            Authorization: `Bearer ${apiKey}`,
+            'Content-Type': 'application/json',
+          },
+          body: JSON.stringify({
+            model,
+            messages: [
+              { role: 'system', content: systemPrompt },
+              { role: 'user', content: userPrompt },
+            ],
+            temperature: 0.2,
+          }),
+        },
+      );
+
+      if (!response.ok) {
+        const errorText = await response.text();
+        console.error('AI API request failed', {
+          status: response.status,
+          error: errorText,
+        });
+        throw new Error(`AI API error ${response.status}: ${errorText}`);
+      }
+
+      const data = await response.json();
+      const content = data.choices?.[0]?.message?.content || '';
+
+      if (!content) {
+        console.error('Empty response from AI');
+        throw new Error('Empty response from AI');
+      }
+
+      return content.trim();
+    } catch (error) {
+      lastError = error instanceof Error ? error : new Error(String(error));
+      console.warn(
+        `AI request attempt ${attempt}/${MAX_RETRIES} failed: ${lastError.message}`,
+      );
+      if (attempt < MAX_RETRIES)
+        await new Promise((r) => setTimeout(r, 1000 * attempt));
+    }
   }
 
-  const data = await response.json();
-  const content = data.choices?.[0]?.message?.content || '';
-
-  if (!content) {
-    console.error('Empty response from AI');
-    throw new Error('Empty response from AI');
-  }
-
-  return content.trim();
+  throw lastError;
 }
+
 export async function generateRevisionSummary(
   apiKey: string,
   model: string,


### PR DESCRIPTION
## Problem
openrouter/auto would occasionally return an empty response on the first attempt dt, causing the entire section review to fail with Empty response from AI and requiring a manual re-trigger.
### Solution
Wrapped reviewArticleSection in a 3-attempt retry loop  now recover automatically without any change to model selection or request structure.