### PR TITLE
fix(avatars): reset legacy iran.liara avatars to trigger regeneration

### DIFF
--- a/supabase/migrations/20260326100141_reset_iran_liara_avatars.sql
+++ b/supabase/migrations/20260326100141_reset_iran_liara_avatars.sql
@@ -1,5 +1,4 @@
 -- Reset avatar_url only for users whose avatar is from avatar.iran.liara.run
--- (the old broken provider). Google, ui-avatars, and storage URLs are kept as-is.
 -- On next login, App.vue detects avatar_url = NULL and regenerates via POST /user/avatar.
 UPDATE public.profiles
 SET

--- a/supabase/migrations/20260326100141_reset_iran_liara_avatars.sql
+++ b/supabase/migrations/20260326100141_reset_iran_liara_avatars.sql
@@ -1,0 +1,9 @@
+-- Reset avatar_url only for users whose avatar is from avatar.iran.liara.run
+-- (the old broken provider). Google, ui-avatars, and storage URLs are kept as-is.
+-- On next login, App.vue detects avatar_url = NULL and regenerates via POST /user/avatar.
+UPDATE public.profiles
+SET
+  avatar_url     = NULL,
+  default_avatar = FALSE
+WHERE
+  avatar_url LIKE '%avatar.iran.liara.run%';


### PR DESCRIPTION
### Description

This PR introduces a migration to clean up broken avatars generated from the deprecated avatar.iran.liara.run provider.

**What it does** 
Targets named users (email IS NOT NULL) using the old default avatar (default_avatar = true)
Resets:
avatar_url = NULL
default_avatar = false