### PR TITLE
automatic periodic cleanup of anon accounts

### DIFF
--- a/supabase/functions/article/deleteAllArticles.ts
+++ b/supabase/functions/article/deleteAllArticles.ts
@@ -10,12 +10,10 @@ import { deleteArticleByArticleId } from "./deleteArticle.ts";
  */
 export async function deleteAllArticles(context: Context) {
   const authHeader = context.req.header("Authorization");
-  const apiKey = context.req.header("apikey");
 
   const serviceRoleKey = Deno.env.get("SUPABASE_SERVICE_ROLE_KEY");
 
-  const isServiceRole = apiKey === serviceRoleKey ||
-    authHeader === `Bearer ${serviceRoleKey}`;
+  const isServiceRole = authHeader === `Bearer ${serviceRoleKey}`;
 
   console.log("Internal request?:", isServiceRole);
 

--- a/supabase/functions/article/deleteAllArticles.ts
+++ b/supabase/functions/article/deleteAllArticles.ts
@@ -1,29 +1,54 @@
-import { Context } from 'npm:hono@4.7.4';
-import { getOwnedArticles } from '../_shared/helpers/supabaseHelper.ts';
-import createSupabaseClient from '../_shared/supabaseClient.ts';
-import { deleteArticleByArticleId } from './deleteArticle.ts';
+import { Context } from "npm:hono@4.7.4";
+import { getOwnedArticles } from "../_shared/helpers/supabaseHelper.ts";
+import createSupabaseAdmin from "../_shared/supabaseAdmin.ts";
+import createSupabaseClient from "../_shared/supabaseClient.ts";
+import { deleteArticleByArticleId } from "./deleteArticle.ts";
 
 /**
  * Retrieves Wikipedia articles based on the provided search term and language.
  * @param {Context} context - The Hono context object.
  */
 export async function deleteAllArticles(context: Context) {
-  const supabaseClient = createSupabaseClient(
-    context.req.header('Authorization')
-  );
+  const authHeader = context.req.header("Authorization");
+  const apiKey = context.req.header("apikey");
 
-  const {
-    data: { user },
-  } = await supabaseClient.auth.getUser();
+  const serviceRoleKey = Deno.env.get("SUPABASE_SERVICE_ROLE_KEY");
 
-  if (!user) {
-    return new Response('', {
-      status: 401,
-    });
+  const isServiceRole = apiKey === serviceRoleKey ||
+    authHeader === `Bearer ${serviceRoleKey}`;
+
+  console.log("Internal request?:", isServiceRole);
+
+  let user_id: string | null = null;
+  let supabaseClient;
+
+  if (!isServiceRole) {
+    supabaseClient = createSupabaseClient(authHeader);
+    const {
+      data: { user },
+    } = await supabaseClient.auth.getUser();
+
+    if (!user) {
+      return new Response(``, {
+        status: 401,
+      });
+    }
+
+    user_id = user.id;
+  } else {
+    user_id = context.req.header("x-user-id") || null;
+    supabaseClient = createSupabaseAdmin();
   }
 
+  if (!user_id || !supabaseClient) {
+    console.error("Unauthorized: No user ID or Supabase client available");
+    return new Response("", { status: 400 });
+  }
+
+  console.log("deleting all articles for user:", user_id);
+
   try {
-    const articles = await getOwnedArticles(user.id);
+    const articles = await getOwnedArticles(user_id);
 
     for (const article of articles) {
       try {
@@ -33,7 +58,7 @@ export async function deleteAllArticles(context: Context) {
         console.error(`Failed to delete article ${article.article_id}:`, error);
       }
     }
-    return context.json({ message: 'All articles deleted' }, 200);
+    return context.json({ message: "All articles deleted" }, 200);
   } catch (error) {
     console.error(error);
     if (error instanceof Error) {
@@ -41,9 +66,9 @@ export async function deleteAllArticles(context: Context) {
     }
     return context.json(
       {
-        error: 'An unexpected error occurred while deleting articles',
+        error: "An unexpected error occurred while deleting articles",
       },
-      500
+      500,
     );
   }
 }

--- a/supabase/migrations/20260512120000_cleanup_old_anonymous_accounts.sql
+++ b/supabase/migrations/20260512120000_cleanup_old_anonymous_accounts.sql
@@ -1,0 +1,172 @@
+-- Cleanup old anonymous accounts migration
+
+-- Manually insert the service_role_key into vault.secrets before running this migration like so:
+-- INSERT INTO vault.secrets (name, secret)
+-- VALUES ('service_role_key', 'YOUR_SECRET_VALUE');
+
+-- Add optional_user_id to delete_user_and_anonymize_data
+CREATE OR REPLACE FUNCTION public.delete_user_and_anonymize_data(optional_user_id uuid DEFAULT NULL)
+RETURNS void
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  anonymous_id uuid;
+  target_user_id uuid;
+BEGIN
+
+  -- fallback logic
+  target_user_id := COALESCE(optional_user_id, auth.uid());
+
+  -- safety check
+  IF target_user_id IS NULL THEN
+    RAISE EXCEPTION 'No target_user_id provided and no auth.uid() available';
+  END IF;
+
+  -- delete articles owned by user
+  DELETE FROM articles
+  WHERE id IN (
+    SELECT article_id
+    FROM permissions
+    WHERE role = 'owner'
+      AND user_id = target_user_id
+  );
+
+  -- get anonymous fallback user
+  SELECT id INTO anonymous_id
+  FROM profiles
+  WHERE email = 'deleted-user@wikiadviser.io'
+  LIMIT 1;
+
+  -- reassign data
+  UPDATE changes
+  SET contributor_id = anonymous_id
+  WHERE contributor_id = target_user_id;
+
+  UPDATE comments
+  SET commenter_id = anonymous_id
+  WHERE commenter_id = target_user_id;
+
+  -- cleanup relations
+  DELETE FROM permissions
+  WHERE user_id = target_user_id;
+
+  DELETE FROM profiles
+  WHERE id = target_user_id;
+
+END;
+$$;
+
+-- Generic invoke_edge_function to call edge functions from SQL
+CREATE OR REPLACE FUNCTION private.invoke_edge_function(
+    edge_function_name TEXT,
+    body JSONB DEFAULT '{}'::jsonb,
+    method TEXT DEFAULT 'POST'
+)
+RETURNS JSONB
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = ''
+AS $$
+DECLARE
+    project_url TEXT;
+    service_role_key TEXT;
+    response JSONB;
+BEGIN
+    SELECT decrypted_secret INTO project_url
+    FROM vault.decrypted_secrets
+    WHERE name = 'supabase_project_url';
+
+    SELECT decrypted_secret INTO service_role_key
+    FROM vault.decrypted_secrets
+    WHERE name = 'service_role_key';
+
+    IF project_url IS NULL OR service_role_key IS NULL THEN
+        RAISE EXCEPTION 'Missing vault secrets: project_url or service_role_key';
+    END IF;
+
+    method := UPPER(method);
+
+    IF method = 'DELETE' THEN
+		response := net.http_delete(
+			url := project_url || '/functions/v1/' || edge_function_name,
+			headers := jsonb_build_object(
+				'Content-Type', 'application/json',
+				'Authorization', 'Bearer ' || service_role_key,
+				'apikey', service_role_key,
+				'x-user-id', body->>'user_id' -- pg_net doesnt currently support body in DELETE requests, so we pass user_id as a header
+			)
+		);
+    ELSE
+        response := net.http_post(
+            url := project_url || '/functions/v1/' || edge_function_name,
+            headers := jsonb_build_object(
+                'Content-Type', 'application/json',
+                'Authorization', 'Bearer ' || service_role_key,
+                'apikey', service_role_key
+            ),
+            body := body
+        );
+    END IF;
+
+    RETURN response;
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION private.cleanup_inactive_anon_users()
+RETURNS void
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = ''
+AS $$
+DECLARE
+    u RECORD;
+BEGIN
+    FOR u IN
+        SELECT p.id
+        FROM public.profiles p
+        JOIN auth.users au ON au.id = p.id
+		WHERE au.is_anonymous IS TRUE
+		
+		AND EXISTS (
+            SELECT 1
+            FROM public.permissions per
+            WHERE per.user_id = p.id
+        )
+        AND NOT (
+            au.created_at >= NOW() - INTERVAL '90 days'
+            OR EXISTS (
+                SELECT 1
+                FROM (
+                    SELECT user_id AS id, created_at FROM public.permissions
+                    UNION ALL
+                    SELECT commenter_id, created_at FROM public.comments
+                    UNION ALL
+                    SELECT contributor_id, created_at FROM public.changes
+                ) activity
+                WHERE activity.id = p.id
+                  AND activity.created_at >= NOW() - INTERVAL '90 days'
+            )
+        )
+    LOOP
+        -- 1. Edge function cleanup
+        PERFORM private.invoke_edge_function(
+            'article',
+            jsonb_build_object(
+                'user_id', u.id
+            ),
+            'DELETE'
+        );
+
+        -- 2. DB cleanup
+        PERFORM public.delete_user_and_anonymize_data(u.id);
+    END LOOP;
+END;
+$$;
+
+SELECT cron.schedule(
+    'cleanup-inactive-anon-users-weekly',
+    '0 3 * * 0',  -- every Sunday at 03:00
+    $$ SELECT private.cleanup_inactive_anon_users(); $$
+);

--- a/supabase/migrations/20260512120000_cleanup_old_anonymous_accounts.sql
+++ b/supabase/migrations/20260512120000_cleanup_old_anonymous_accounts.sql
@@ -94,7 +94,6 @@ BEGIN
 			headers := jsonb_build_object(
 				'Content-Type', 'application/json',
 				'Authorization', 'Bearer ' || service_role_key,
-				'apikey', service_role_key,
 				'x-user-id', body->>'user_id' -- pg_net doesnt currently support body in DELETE requests, so we pass user_id as a header
 			)
 		);
@@ -104,7 +103,6 @@ BEGIN
             headers := jsonb_build_object(
                 'Content-Type', 'application/json',
                 'Authorization', 'Bearer ' || service_role_key,
-                'apikey', service_role_key
             ),
             body := body
         );


### PR DESCRIPTION
- added a Generic `invoke_edge_function` to call edge functions from SQL that accepts POST (+ body) & DELETE (+ `x-user-id` header as pg_net doesnt currently support body)
- Added `optional_user_id` to `delete_user_and_anonymize_data` so it can be used in the function
- Added `cleanup_inactive_anon_users` that cleans and loops over inactive anon users (that  have no new (>90 days) account, comments, changes, permissions using 
- Added a cron job `cleanup-inactive-anon-users-weekly`