### PR TITLE
MwVisualEditor Refactor

### DIFF
--- a/docker/resources/common-files/Common-en.js
+++ b/docker/resources/common-files/Common-en.js
@@ -368,6 +368,29 @@ mw.loader.using( [ 'mediawiki.util' ] ).done( function () {
         };
       });
       
+// If its gotodiff param, redirect to diff page (good for Mira diffing)
+$(function () {
+    if (!mw.util.getParamValue("gotodiff")) {
+        return;
+    }
+
+    const articleId = this.getPageName();
+    if (!articleId) {
+        return;
+    }
+
+    console.log("[WikiAdviser] gotodiff param detected, redirecting to diff page for article:", articleId);
+
+    mw.wikiadviser.getDiffUrl(articleId)
+        .then(function (diffUrl) {
+            console.log("[WikiAdviser] Redirect:", diffUrl);
+            window.location.replace(diffUrl);
+        })
+        .catch(function (error) {
+            console.error("[WikiAdviser] Failed:", error);
+        });
+});
+
 // Source Editor Save Handling
 $(function() {
   if (!isIframe) return;

--- a/docker/resources/common-files/Common-en.js
+++ b/docker/resources/common-files/Common-en.js
@@ -370,7 +370,7 @@ mw.loader.using( [ 'mediawiki.util' ] ).done( function () {
       
 // If its gotodiff param, redirect to diff page (good for Mira diffing)
 $(function () {
-    if (!mw.util.getParamValue("gotodiff")) {
+    if (!mw.util.getParamValue("wikiadviser") || !mw.util.getParamValue("gotodiff")) {
         return;
     }
 

--- a/docker/resources/common-files/Common-en.js
+++ b/docker/resources/common-files/Common-en.js
@@ -370,11 +370,12 @@ mw.loader.using( [ 'mediawiki.util' ] ).done( function () {
       
 // If its gotodiff param, redirect to diff page (good for Mira diffing)
 $(function () {
-    if (!mw.util.getParamValue("wikiadviser") || !mw.util.getParamValue("gotodiff")) {
-        return;
-    }
+  console.log("[WikiAdviser] Checking for gotodiff param...",mw.util.getParamValue("gotodiff"));
+    // Has params "gotodiff" & "wikiadviser"
+    const urlParams = new URLSearchParams(window.location.search);
+    if (!urlParams.has('wikiadviser') || !urlParams.has('gotodiff')) return;
 
-    const articleId = this.getPageName();
+    const articleId = mw.config.get('wgPageName');
     if (!articleId) {
         return;
     }

--- a/docker/resources/common-files/Common-fr.js
+++ b/docker/resources/common-files/Common-fr.js
@@ -923,7 +923,7 @@ mw.hook( 'wikipage.content' ).add( addBibSubsetMenu );
       
 // If its gotodiff param, redirect to diff page (good for Mira diffing)
 $(function () {
-    if (!mw.util.getParamValue("gotodiff")) {
+    if (!mw.util.getParamValue("wikiadviser") || !mw.util.getParamValue("gotodiff")) {
         return;
     }
 
@@ -943,6 +943,7 @@ $(function () {
             console.error("[WikiAdviser] Failed:", error);
         });
 });
+
 
 // Source Editor Save Handling
 $(function() {

--- a/docker/resources/common-files/Common-fr.js
+++ b/docker/resources/common-files/Common-fr.js
@@ -921,6 +921,29 @@ mw.hook( 'wikipage.content' ).add( addBibSubsetMenu );
         };
       });
       
+// If its gotodiff param, redirect to diff page (good for Mira diffing)
+$(function () {
+    if (!mw.util.getParamValue("gotodiff")) {
+        return;
+    }
+
+    const articleId = this.getPageName();
+    if (!articleId) {
+        return;
+    }
+
+    console.log("[WikiAdviser] gotodiff param detected, redirecting to diff page for article:", articleId);
+
+    mw.wikiadviser.getDiffUrl(articleId)
+        .then(function (diffUrl) {
+            console.log("[WikiAdviser] Redirect:", diffUrl);
+            window.location.replace(diffUrl);
+        })
+        .catch(function (error) {
+            console.error("[WikiAdviser] Failed:", error);
+        });
+});
+
 // Source Editor Save Handling
 $(function() {
   if (!isIframe) return;

--- a/docker/resources/common-files/Common-fr.js
+++ b/docker/resources/common-files/Common-fr.js
@@ -923,11 +923,12 @@ mw.hook( 'wikipage.content' ).add( addBibSubsetMenu );
       
 // If its gotodiff param, redirect to diff page (good for Mira diffing)
 $(function () {
-    if (!mw.util.getParamValue("wikiadviser") || !mw.util.getParamValue("gotodiff")) {
-        return;
-    }
+  console.log("[WikiAdviser] Checking for gotodiff param...",mw.util.getParamValue("gotodiff"));
+    // Has params "gotodiff" & "wikiadviser"
+    const urlParams = new URLSearchParams(window.location.search);
+    if (!urlParams.has('wikiadviser') || !urlParams.has('gotodiff')) return;
 
-    const articleId = this.getPageName();
+    const articleId = mw.config.get('wgPageName');
     if (!articleId) {
         return;
     }
@@ -943,7 +944,6 @@ $(function () {
             console.error("[WikiAdviser] Failed:", error);
         });
 });
-
 
 // Source Editor Save Handling
 $(function() {

--- a/docker/resources/common-files/Common.js
+++ b/docker/resources/common-files/Common.js
@@ -231,7 +231,7 @@ mw.hook("ve.activationComplete").add(function () {
 
 // If its gotodiff param, redirect to diff page (good for Mira diffing)
 $(function () {
-    if (!mw.util.getParamValue("gotodiff")) {
+    if (!mw.util.getParamValue("wikiadviser") || !mw.util.getParamValue("gotodiff")) {
         return;
     }
 
@@ -251,6 +251,7 @@ $(function () {
             console.error("[WikiAdviser] Failed:", error);
         });
 });
+
 
 // Source Editor Save Handling
 $(function () {

--- a/docker/resources/common-files/Common.js
+++ b/docker/resources/common-files/Common.js
@@ -229,6 +229,29 @@ mw.hook("ve.activationComplete").add(function () {
   };
 });
 
+// If its gotodiff param, redirect to diff page (good for Mira diffing)
+$(function () {
+    if (!mw.util.getParamValue("gotodiff")) {
+        return;
+    }
+
+    const articleId = this.getPageName();
+    if (!articleId) {
+        return;
+    }
+
+    console.log("[WikiAdviser] gotodiff param detected, redirecting to diff page for article:", articleId);
+
+    mw.wikiadviser.getDiffUrl(articleId)
+        .then(function (diffUrl) {
+            console.log("[WikiAdviser] Redirect:", diffUrl);
+            window.location.replace(diffUrl);
+        })
+        .catch(function (error) {
+            console.error("[WikiAdviser] Failed:", error);
+        });
+});
+
 // Source Editor Save Handling
 $(function () {
   if (!isIframe) return;

--- a/docker/resources/common-files/Common.js
+++ b/docker/resources/common-files/Common.js
@@ -231,11 +231,12 @@ mw.hook("ve.activationComplete").add(function () {
 
 // If its gotodiff param, redirect to diff page (good for Mira diffing)
 $(function () {
-    if (!mw.util.getParamValue("wikiadviser") || !mw.util.getParamValue("gotodiff")) {
-        return;
-    }
+  console.log("[WikiAdviser] Checking for gotodiff param...",mw.util.getParamValue("gotodiff"));
+    // Has params "gotodiff" & "wikiadviser"
+    const urlParams = new URLSearchParams(window.location.search);
+    if (!urlParams.has('wikiadviser') || !urlParams.has('gotodiff')) return;
 
-    const articleId = this.getPageName();
+    const articleId = mw.config.get('wgPageName');
     if (!articleId) {
         return;
     }
@@ -251,7 +252,6 @@ $(function () {
             console.error("[WikiAdviser] Failed:", error);
         });
 });
-
 
 // Source Editor Save Handling
 $(function () {

--- a/frontend/src/components/MwVisualEditor.vue
+++ b/frontend/src/components/MwVisualEditor.vue
@@ -72,7 +72,6 @@ const iframeRef = ref();
 const isProcessingChanges = ref(false);
 
 const renderIframe = ref(true);
-let diffTimeout: ReturnType<typeof setTimeout> | null = null;
 
 async function reloadIframe() {
   renderIframe.value = false;
@@ -145,7 +144,7 @@ async function handleDiffChange(data: {
   // the editor after the user accepts/rejects.
 }
 
-async function handleIgnoredInitialEdit() {
+function handleIgnoredInitialEdit() {
   $q.notify({
     message: 'Changes successfully updated',
     icon: 'check',
@@ -161,7 +160,7 @@ async function EventHandler(event: MessageEvent): Promise<void> {
   console.log('[MwVisualEditor] Received event:', data);
   switch (data.type) {
     case 'ignored-initial-edit':
-      await handleIgnoredInitialEdit();
+      handleIgnoredInitialEdit();
       break;
     case 'diff-change':
       await handleDiffChange(data);
@@ -228,7 +227,6 @@ onMounted(() => {
 
 onBeforeUnmount(() => {
   window.removeEventListener('message', EventHandler);
-  if (diffTimeout) clearTimeout(diffTimeout);
   miraStore.$reset();
 });
 </script>

--- a/frontend/src/components/MwVisualEditor.vue
+++ b/frontend/src/components/MwVisualEditor.vue
@@ -60,11 +60,6 @@ const baseArticleLink = `${mediawikiBaseUrl}/index.php?title=${encodeURIComponen
 const veLink = `${baseArticleLink}&veaction=edit`;
 const articleLink = ref(veLink);
 
-function navigateToVE() {
-  loading.value = { ...loaderPresets.editor };
-  articleLink.value = veLink;
-  reloadIframe();
-}
 const loaderPresets = {
   editor: { value: true, message: 'Loading Editor' },
   changes: {
@@ -83,6 +78,11 @@ async function reloadIframe() {
   renderIframe.value = false;
   await nextTick();
   renderIframe.value = true;
+}
+function navigateToVE() {
+  loading.value = { ...loaderPresets.editor };
+  articleLink.value = veLink;
+  reloadIframe();
 }
 
 // Reload the iframe pointing at the editor URL with gotodiff=1 appended.

--- a/frontend/src/components/MwVisualEditor.vue
+++ b/frontend/src/components/MwVisualEditor.vue
@@ -54,9 +54,17 @@ const activeViewStore = useActiveViewStore();
 const miraStore = useMiraReviewStore();
 
 const mediawikiBaseUrl = `${ENV.MEDIAWIKI_ENDPOINT}/${props.article.language}`;
-const articleLink = ref(
-  `${mediawikiBaseUrl}/index.php?title=${props.article.article_id}&veaction=edit`,
-);
+const baseArticleLink = `${mediawikiBaseUrl}/index.php?title=${encodeURIComponent(
+  props.article.article_id,
+)}`;
+const veLink = `${baseArticleLink}&veaction=edit`;
+const articleLink = ref(veLink);
+
+function navigateToVE() {
+  loading.value = { ...loaderPresets.editor };
+  articleLink.value = veLink;
+  reloadIframe();
+}
 const loaderPresets = {
   editor: { value: true, message: 'Loading Editor' },
   changes: {
@@ -69,39 +77,27 @@ const iframeRef = ref();
 const isProcessingChanges = ref(false);
 
 const renderIframe = ref(true);
-const pendingDiffAfterLoad = ref(false);
 let diffTimeout: ReturnType<typeof setTimeout> | null = null;
+
 async function reloadIframe() {
   renderIframe.value = false;
   await nextTick();
   renderIframe.value = true;
 }
-function gotoDiffLink() {
-  activeViewStore.modeToggle = 'edit';
 
-  if (!iframeRef.value?.contentWindow) {
-    pendingDiffAfterLoad.value = true;
-    activeViewStore.modeToggle = 'edit';
-    return;
-  }
-
-  iframeRef.value.contentWindow.postMessage(
-    {
-      type: 'wikiadviser',
-      data: 'diff',
-      articleId: props.article.article_id,
-    },
-    '*',
-  );
+// Reload the iframe pointing at the editor URL with gotodiff=1 appended.
+// MediaWiki's Common.js detects the param, fetches the diff URL via
+// mw.wikiadviser.getDiffUrl(), and replaces window.location to land on
+// the diff page. This sidesteps the cross-origin postMessage race that
+// made the old "send event to iframe" approach unreliable.
+async function navigateToDiff() {
+  isProcessingChanges.value = true;
+  loading.value = { ...loaderPresets.changes };
+  articleLink.value = `${baseArticleLink}&gotodiff&wikiadviser`;
+  await reloadIframe();
 }
-async function onIframeLoad() {
-  if (pendingDiffAfterLoad.value) {
-    pendingDiffAfterLoad.value = false;
-    loading.value.value = false;
-    gotoDiffLink();
-    return;
-  }
 
+function onIframeLoad() {
   loading.value.value = false;
 }
 
@@ -110,10 +106,7 @@ async function handleDiffChange(data: {
   diffHtml: string;
   articleId: string;
 }) {
-  pendingDiffAfterLoad.value = false;
-
   const functionName = `/article/${data.articleId}/changes`;
-
   const body: { diffHtml: string; miraBotId?: string } = {
     diffHtml: data.diffHtml,
   };
@@ -135,7 +128,7 @@ async function handleDiffChange(data: {
       color: 'negative',
     });
     isProcessingChanges.value = false;
-    loading.value = { ...loaderPresets.editor };
+    navigateToVE();
     return;
   }
 
@@ -147,8 +140,9 @@ async function handleDiffChange(data: {
     color: 'positive',
   });
   isProcessingChanges.value = false;
-  loading.value = { ...loaderPresets.editor };
-  reloadIframe();
+  navigateToVE();
+  // The diff page in the iframe handles its own navigation back to
+  // the editor after the user accepts/rejects.
 }
 
 async function handleIgnoredInitialEdit() {
@@ -158,21 +152,19 @@ async function handleIgnoredInitialEdit() {
     color: 'positive',
   });
   isProcessingChanges.value = false;
-  loading.value = { ...loaderPresets.editor };
-  await reloadIframe();
+  navigateToVE();
 }
 
 async function EventHandler(event: MessageEvent): Promise<void> {
   const { data } = event;
 
-  if (data.type === 'diff-change') {
-    await handleDiffChange(data);
-    return;
-  }
-
+  console.log('[MwVisualEditor] Received event:', data);
   switch (data.type) {
     case 'ignored-initial-edit':
       await handleIgnoredInitialEdit();
+      break;
+    case 'diff-change':
+      await handleDiffChange(data);
       break;
     case 'saved-changes':
       isProcessingChanges.value = true;
@@ -187,11 +179,11 @@ async function EventHandler(event: MessageEvent): Promise<void> {
       } catch (e) {
         console.warn('[MwVisualEditor] Failed to set pending diff:', e);
       }
+      isProcessingChanges.value = false;
+      navigateToVE();
       break;
     case 'deleted-revision':
-      isProcessingChanges.value = true;
-      loading.value = { ...loaderPresets.changes };
-      gotoDiffLink();
+      await navigateToDiff();
       break;
     case 'diff-error':
       console.error('[MwVisualEditor] Diff navigation failed:', data.error);
@@ -208,48 +200,24 @@ async function EventHandler(event: MessageEvent): Promise<void> {
   }
 }
 
-async function handleDiffPending() {
-  isProcessingChanges.value = true;
-  loading.value = { value: true, message: loaderPresets.changes.message };
-  diffTimeout = setTimeout(() => {
-    loading.value.value = false;
-    isProcessingChanges.value = false;
-    miraStore.completeDiffUpdate();
-    $q.notify({
-      message:
-        'We are still processing changes, here you can see what is happening behind the scenes.',
-      icon: 'info',
-      color: 'info',
-    });
-  }, 20000);
-
-  pendingDiffAfterLoad.value = true;
-  activeViewStore.modeToggle = 'edit';
-
-  // If the iframe is already rendered, its load event already fired
-  // before we got here, so onIframeLoad will never see
-  // pendingDiffAfterLoad=true. Post the message directly and let
-  // onIframeLoad hide the overlay when the diff page actually loads.
-  if (iframeRef.value) {
-    pendingDiffAfterLoad.value = false;
-    gotoDiffLink();
-  }
-}
-
+// AI review just completed — show the "still processing" UX toast and
+// reload the iframe with gotodiff=1 to navigate to the diff page.
 watch(
   () => miraStore.isDiffUpdatePending,
   (pending) => {
+    console.log('[MwVisualEditor] isDiffUpdatePending changed:', pending);
     if (!pending) return;
-    handleDiffPending();
+    navigateToDiff();
   },
-  { immediate: true },
 );
 
+// Page loaded with pending_diff=true (e.g. user reloaded a wikiadviser
+// that already has pending changes). immediate:true fires once on mount.
 watch(
   () => props.article.pending_diff,
   (pending) => {
-    if (!pending) return;
-    handleDiffPending();
+    console.log('[MwVisualEditor] article.pending_diff changed:', pending);
+    if (pending) navigateToDiff();
   },
   { immediate: true },
 );


### PR DESCRIPTION
- If mediawiki article has `gotodiff` param, it redirects to diff page, so we just add that param to the iframe link and diff is kickstarted, this is better than `postMessage` to the iframe (unreliable in many cases)
- refactor MwVisualEditor.vue