### PR TITLE
only free models are allowed while using Global OPENROUTER_API_KEY 

### DIFF
--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -23,7 +23,7 @@ MEDIAWIKI_ENDPOINT="http://localhost:8080/wiki"
 # Enable or disable Mira AI Assistant
 USE_MIRA = true
 # AI Model to be used
-AI_MODEL=google/gemini-2.5-flash-lite
+AI_MODEL=openrouter/free
 
 # Enable or disable Change Description feature
 USE_CHANGE_DESCRIPTION = true

--- a/frontend/src/pages/auth/UserAccountPage.vue
+++ b/frontend/src/pages/auth/UserAccountPage.vue
@@ -211,8 +211,8 @@
                 Your API Key is safely stored and encrypted in our secrets vault
               </span>
               <span v-else>
-                Using global API key. Add your own OpenRouter API key to
-                customize.
+                Using global API key. Only free OpenRouter models are available.
+                Add your own OpenRouter key to unlock all models.
               </span>
               <template #action>
                 <q-btn
@@ -446,6 +446,13 @@ interface ModelOption {
   id: string;
   name: string;
   context: number;
+  isFree: boolean;
+}
+
+function isFreeModel(model: string): boolean {
+  if (!model) return false;
+  if (model === 'openrouter/free') return true;
+  return model.endsWith(':free');
 }
 
 interface OpenRouterModel {
@@ -653,6 +660,8 @@ const apiKey = ref({
   showRemoveDialog: false,
 });
 
+const usingGlobalKey = computed(() => !apiKey.value.hasPersonalKey);
+
 const allModelOptions = ref<ModelOption[]>([]);
 const filteredModelOptions = ref<ModelOption[]>([]);
 const loadingModels = ref(false);
@@ -801,10 +810,14 @@ async function loadModelsFromAPI() {
         id: model.id,
         name: `${model.id} (${model.context_length} tokens)`,
         context: model.context_length,
+        isFree: isFreeModel(model.id),
       }))
       .sort((a: ModelOption, b: ModelOption) => b.context - a.context);
 
-    filteredModelOptions.value = allModelOptions.value.slice(0, 50);
+    const initialPool = usingGlobalKey.value
+      ? allModelOptions.value.filter((m: ModelOption) => m.isFree)
+      : allModelOptions.value;
+    filteredModelOptions.value = initialPool.slice(0, 50);
   } catch (error) {
     console.error('Error fetching models:', error);
   } finally {
@@ -817,12 +830,18 @@ function filterModels(val: string, update: (fn: () => void) => void) {
     loadModelsFromAPI();
   }
 
+  const restrictToFree = usingGlobalKey.value;
+
   update(() => {
+    let pool = allModelOptions.value;
+    if (restrictToFree) {
+      pool = pool.filter((model: ModelOption) => model.isFree);
+    }
     if (val === '') {
-      filteredModelOptions.value = allModelOptions.value.slice(0, 50);
+      filteredModelOptions.value = pool.slice(0, 50);
     } else {
       const needle = val.toLowerCase();
-      filteredModelOptions.value = allModelOptions.value
+      filteredModelOptions.value = pool
         .filter((model: ModelOption) => model.id.toLowerCase().includes(needle))
         .slice(0, 50);
     }
@@ -842,6 +861,21 @@ function onProviderChange(newProvider: string) {
 async function saveLLMConfig() {
   const userId = userStore.user?.id;
   if (!userId) return;
+
+  if (
+    llmConfig.value.provider === 'openrouter' &&
+    !apiKey.value.hasPersonalKey &&
+    !apiKey.value.input?.trim() &&
+    llmConfig.value.model &&
+    !isFreeModel(llmConfig.value.model)
+  ) {
+    $q.notify({
+      message: 'Only free models are allowed when using the global API key ',
+      icon: 'error',
+      color: 'negative',
+    });
+    return;
+  }
 
   savingLLMConfig.value = true;
   try {
@@ -883,6 +917,14 @@ async function loadLLMConfig() {
       endpoint: config.endpoint || null,
     };
     apiKey.value.hasPersonalKey = config.has_api_key || false;
+  }
+  if (
+    llmConfig.value.provider === 'openrouter' &&
+    !apiKey.value.hasPersonalKey &&
+    llmConfig.value.model &&
+    !isFreeModel(llmConfig.value.model)
+  ) {
+    llmConfig.value.model = DEFAULT_AI_MODEL;
   }
   if (llmConfig.value.provider !== 'openrouter') {
     filteredModelOptions.value = [];

--- a/frontend/src/schema/env.schema.ts
+++ b/frontend/src/schema/env.schema.ts
@@ -37,7 +37,7 @@ const envSchema = z.object({
   POSTHOG_API_HOST: z.string().optional(),
   USE_MIRA: z.boolean().default(false),
   USE_CHANGE_DESCRIPTION: z.boolean().default(true),
-  AI_MODEL: z.string().default('google/gemini-2.5-flash-lite'),
+  AI_MODEL: z.string().default('openrouter/free'),
   AI_BOT_EMAIL: z.string().default('mira@wikiadviser.io'),
   AI_PROVIDER: z.string().default('openrouter'),
 });

--- a/supabase/functions/.env.example
+++ b/supabase/functions/.env.example
@@ -31,8 +31,12 @@ OPENROUTER_API_KEY=your-secret-openrouter-api-key
 # AI Bot Email
 AI_BOT_EMAIL=mira@wikiadviser.io
 
-# AI Model to be used
-AI_MODEL=google/gemini-2.5-flash-lite
+# AI Model to be used.
+# When using the global OPENROUTER_API_KEY, only free models are allowed:
+#   - the "openrouter/free" router (random free model, recommended)
+#   - any model ending in ":free" (e.g. "openai/gpt-oss-20b:free")
+# When users add their own OpenRouter key in account settings, any model is allowed.
+AI_MODEL=openrouter/free
 
 # AI Provider (openrouter | openai | anthropic | gemini | custom)
 AI_PROVIDER=openrouter

--- a/supabase/functions/ai-review/services/aiService.ts
+++ b/supabase/functions/ai-review/services/aiService.ts
@@ -1,4 +1,5 @@
 import { LLMConfig } from '../utils/types.ts';
+import { assertFreeModelAllowed } from '../utils/freeModelGuard.ts';
 import { OpenAICompatibleProvider } from './providers/openai-compatible.ts';
 import { AnthropicProvider } from './providers/anthropic.ts';
 import { GeminiProvider } from './providers/gemini.ts';
@@ -36,6 +37,7 @@ export async function reviewArticleSection(
   userPrompt: string,
   maxTokens?: number,
 ): Promise<string> {
+  assertFreeModelAllowed(config);
   const provider = getProvider(config);
   console.log(`[AI Review] Starting review with provider="${config.provider}" model="${config.model}"`);
   let lastError: Error = new Error('Unknown error');
@@ -72,6 +74,7 @@ export async function generateRevisionSummary(
   newText: string,
 ): Promise<string> {
   try {
+    assertFreeModelAllowed(config);
     const provider = getProvider(config);
     console.log(`[AI Summary] Generating summary with provider="${config.provider}" model="${config.model}"`);
     const summary = await provider.chatCompletion({

--- a/supabase/functions/ai-review/services/configService.ts
+++ b/supabase/functions/ai-review/services/configService.ts
@@ -36,7 +36,7 @@ export async function getLLMConfig(
       .single();
 
     let apiKey: string | null = null;
-    let model: string = Deno.env.get('AI_MODEL') ?? 'openai/gpt-4o-mini';
+    let model: string = Deno.env.get('AI_MODEL') ?? 'openrouter/free';
     let provider: AIProviderType = (Deno.env.get('AI_PROVIDER') as AIProviderType) ?? 'openrouter';
     let endpoint: string | null = null;
     let hasUserConfig = false;

--- a/supabase/functions/ai-review/utils/freeModelGuard.ts
+++ b/supabase/functions/ai-review/utils/freeModelGuard.ts
@@ -1,0 +1,16 @@
+import { LLMConfig } from "./types.ts";
+
+const AI_MODEL = Deno.env.get("AI_MODEL");
+export function isFreeModel(model: string): boolean {
+  if (!model) return false;
+  if (model === AI_MODEL) return true;
+  return model.endsWith(":free");
+}
+
+export function assertFreeModelAllowed(config: LLMConfig): void {
+  if (!config.hasUserConfig && !isFreeModel(config.model)) {
+    throw new Error(
+      "Global API key may only be used with free OpenRouter models",
+    );
+  }
+}

--- a/supabase/functions/ai-review/utils/freeModelGuard.ts
+++ b/supabase/functions/ai-review/utils/freeModelGuard.ts
@@ -1,9 +1,8 @@
 import { LLMConfig } from "./types.ts";
 
-const AI_MODEL = Deno.env.get("AI_MODEL");
 export function isFreeModel(model: string): boolean {
   if (!model) return false;
-  if (model === AI_MODEL) return true;
+  if (model === Deno.env.get("AI_MODEL")) return true;
   return model.endsWith(":free");
 }
 

--- a/supabase/functions/tests/ai-review/freeModelGuard.test.ts
+++ b/supabase/functions/tests/ai-review/freeModelGuard.test.ts
@@ -1,0 +1,87 @@
+import {
+  assertEquals,
+  assertThrows,
+} from "https://deno.land/std@0.208.0/assert/mod.ts";
+import { LLMConfig } from "../../ai-review/utils/types.ts";
+import { assertFreeModelAllowed } from "../../ai-review/utils/freeModelGuard.ts";
+
+function makeConfig(overrides: Partial<LLMConfig> = {}): LLMConfig {
+  return {
+    apiKey: "sk-test",
+    prompt: "prompt",
+    model: "openai/gpt-oss-20b:free",
+    hasUserConfig: false,
+    provider: "openrouter",
+    endpoint: null,
+    ...overrides,
+  };
+}
+
+Deno.test(
+  "assertFreeModelAllowed: OpenRouter + global key + :free model passes",
+  () => {
+    const config = makeConfig({
+      hasUserConfig: false,
+      model: "deepseek/deepseek-r1:free",
+    });
+    assertEquals(assertFreeModelAllowed(config), undefined);
+  },
+);
+
+Deno.test(
+  "assertFreeModelAllowed: OpenRouter + global key + openrouter/free router passes",
+  () => {
+    const config = makeConfig({
+      hasUserConfig: false,
+      model: "openrouter/free",
+    });
+    assertEquals(assertFreeModelAllowed(config), undefined);
+  },
+);
+
+Deno.test(
+  "assertFreeModelAllowed: OpenRouter + global key + paid model throws",
+  () => {
+    const config = makeConfig({
+      hasUserConfig: false,
+      model: "openai/gpt-4o",
+    });
+    assertThrows(() => assertFreeModelAllowed(config), Error, "Global API key");
+  },
+);
+
+Deno.test(
+  "assertFreeModelAllowed: OpenRouter + personal key + paid model passes",
+  () => {
+    const config = makeConfig({
+      hasUserConfig: true,
+      model: "openai/gpt-4o",
+    });
+    assertEquals(assertFreeModelAllowed(config), undefined);
+  },
+);
+
+Deno.test(
+  "assertFreeModelAllowed: non-OpenRouter provider + global key passes",
+  () => {
+    const config = makeConfig({
+      hasUserConfig: false,
+      provider: "openai",
+      model: "gpt-4o",
+    });
+    assertEquals(assertFreeModelAllowed(config), undefined);
+  },
+);
+
+Deno.test(
+  "assertFreeModelAllowed: OpenRouter + global key + custom provider endpoint passes",
+  () => {
+    const config = makeConfig({
+      hasUserConfig: false,
+      provider: "custom",
+      model: "whatever",
+      endpoint: "https://example.com/v1",
+    });
+    assertEquals(assertFreeModelAllowed(config), undefined);
+  },
+);

--- a/supabase/functions/tests/ai-review/freeModelGuard.test.ts
+++ b/supabase/functions/tests/ai-review/freeModelGuard.test.ts
@@ -1,5 +1,4 @@
 import {
-  assertEquals,
   assertThrows,
 } from "https://deno.land/std@0.208.0/assert/mod.ts";
 import { LLMConfig } from "../../ai-review/utils/types.ts";
@@ -18,29 +17,29 @@ function makeConfig(overrides: Partial<LLMConfig> = {}): LLMConfig {
 }
 
 Deno.test(
-  "assertFreeModelAllowed: OpenRouter + global key + :free model passes",
+  "assertFreeModelAllowed: global key + :free model passes",
   () => {
     const config = makeConfig({
       hasUserConfig: false,
       model: "deepseek/deepseek-r1:free",
     });
-    assertEquals(assertFreeModelAllowed(config), undefined);
+    assertFreeModelAllowed(config);
   },
 );
 
 Deno.test(
-  "assertFreeModelAllowed: OpenRouter + global key + openrouter/free router passes",
+  "assertFreeModelAllowed: global key + AI_MODEL env default passes",
   () => {
     const config = makeConfig({
       hasUserConfig: false,
       model: "openrouter/free",
     });
-    assertEquals(assertFreeModelAllowed(config), undefined);
+    assertFreeModelAllowed(config);
   },
 );
 
 Deno.test(
-  "assertFreeModelAllowed: OpenRouter + global key + paid model throws",
+  "assertFreeModelAllowed: global key + paid model throws",
   () => {
     const config = makeConfig({
       hasUserConfig: false,
@@ -51,37 +50,37 @@ Deno.test(
 );
 
 Deno.test(
-  "assertFreeModelAllowed: OpenRouter + personal key + paid model passes",
+  "assertFreeModelAllowed: personal key + paid model passes",
   () => {
     const config = makeConfig({
       hasUserConfig: true,
       model: "openai/gpt-4o",
     });
-    assertEquals(assertFreeModelAllowed(config), undefined);
+    assertFreeModelAllowed(config);
   },
 );
 
 Deno.test(
-  "assertFreeModelAllowed: non-OpenRouter provider + global key passes",
-  () => {
-    const config = makeConfig({
-      hasUserConfig: false,
-      provider: "openai",
-      model: "gpt-4o",
-    });
-    assertEquals(assertFreeModelAllowed(config), undefined);
-  },
-);
-
-Deno.test(
-  "assertFreeModelAllowed: OpenRouter + global key + custom provider endpoint passes",
+  "assertFreeModelAllowed: global key + free model + custom provider passes",
   () => {
     const config = makeConfig({
       hasUserConfig: false,
       provider: "custom",
-      model: "whatever",
+      model: "some-model:free",
       endpoint: "https://example.com/v1",
     });
-    assertEquals(assertFreeModelAllowed(config), undefined);
+    assertFreeModelAllowed(config);
+  },
+);
+
+Deno.test(
+  "assertFreeModelAllowed: global key + free model + non-openrouter provider passes",
+  () => {
+    const config = makeConfig({
+      hasUserConfig: false,
+      provider: "openai",
+      model: "gpt-4o:free",
+    });
+    assertFreeModelAllowed(config);
   },
 );

--- a/supabase/functions/tests/ai-review/freeModelGuard.test.ts
+++ b/supabase/functions/tests/ai-review/freeModelGuard.test.ts
@@ -4,6 +4,8 @@ import {
 import { LLMConfig } from "../../ai-review/utils/types.ts";
 import { assertFreeModelAllowed } from "../../ai-review/utils/freeModelGuard.ts";
 
+Deno.env.set("AI_MODEL", "openrouter/free");
+
 function makeConfig(overrides: Partial<LLMConfig> = {}): LLMConfig {
   return {
     apiKey: "sk-test",


### PR DESCRIPTION
When using the global OPENROUTER_API_KEY, only free models are allowed:
   - the "openrouter/free" router (random free model, recommended)
   - any model ending in ":free" (e.g. "openai/gpt-oss-20b:free")

When users add their own OpenRouter key in account settings, any model is allowed.

- resolves #1395 