### PR TITLE
feat(dependabot): group updates, auto-close vendored deps, auto-merge minor/patch, weekly report

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,16 +1,27 @@
-# To get started with Dependabot version updates, you'll need to specify which
-# package ecosystems to update and where the package manifests are located.
-# Please see the documentation for all configuration options:
-# https://docs.github.com/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
-
 version: 2
 updates:
   - package-ecosystem: "npm"
     directory: "/"
     schedule:
       interval: "weekly"
+    open-pull-requests-limit: 5
+    groups:
+      minor-patch:
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"
 
   - package-ecosystem: "npm"
     directory: "/frontend"
     schedule:
       interval: "weekly"
+    open-pull-requests-limit: 5
+    groups:
+      minor-patch:
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"

--- a/.github/workflows/auto-merge-dependabot.yml
+++ b/.github/workflows/auto-merge-dependabot.yml
@@ -1,0 +1,47 @@
+name: Auto-merge Dependabot minor/patch
+on:
+  pull_request_target:
+    types: [opened, reopened, synchronize, labeled, unlabeled]
+
+permissions:
+  pull-requests: write
+  contents: write
+
+jobs:
+  auto-merge:
+    runs-on: ubuntu-latest
+    if: github.actor == 'dependabot[bot]'
+    steps:
+      - uses: actions/github-script@v7
+        id: check
+        with:
+          result-encoding: string
+          script: |
+            const pr = context.payload.pull_request;
+            const labels = pr.labels.map(l => l.name);
+
+            // Skip major updates — they need manual migration review
+            if (labels.includes('semver:major')) {
+              return 'skip';
+            }
+
+            // Skip vendored dep PRs (caught by close-vendored-deps, but be safe)
+            const { data: files } = await github.rest.pulls.listFiles({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: context.issue.number
+            });
+            const isVendored = files.some(f =>
+              f.filename.startsWith('docker/resources/extensions/MyVisualEditor/')
+            );
+            if (isVendored) return 'skip';
+
+            return 'merge';
+
+      - name: Enable auto-merge
+        if: steps.check.outputs.result == 'merge'
+        run: |
+          gh pr merge --auto --squash "$PR_URL"
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_URL: ${{ github.event.pull_request.html_url }}

--- a/.github/workflows/close-vendored-deps.yml
+++ b/.github/workflows/close-vendored-deps.yml
@@ -1,0 +1,36 @@
+name: Close vendored dependency PRs
+on:
+  pull_request_target:
+    types: [opened, reopened]
+    paths:
+      - "docker/resources/extensions/MyVisualEditor/**"
+
+jobs:
+  close:
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+      contents: read
+    if: github.actor == 'dependabot[bot]'
+    steps:
+      - uses: actions/github-script@v7
+        with:
+          script: |
+            const { owner, repo } = context.repo;
+            const number = context.issue.number;
+
+            await github.rest.issues.createComment({
+              owner, repo, issue_number: number,
+              body: [
+                'These npm dependencies are vendored dead weight — not installed or executed in the built image.',
+                'The `docker/resources/extensions/MyVisualEditor` directory is copied as-is into the MediaWiki container;',
+                'no `npm install` or `composer install` is ever run for it.',
+                '',
+                'Closing automatically. No action needed.'
+              ].join('\n')
+            });
+
+            await github.rest.pulls.update({
+              owner, repo, pull_number: number,
+              state: 'closed'
+            });

--- a/.github/workflows/dependabot-weekly-report.yml
+++ b/.github/workflows/dependabot-weekly-report.yml
@@ -1,7 +1,7 @@
 name: Dependabot weekly report
 on:
   schedule:
-    - cron: "9 9 * * 1" # Monday 09:09 UTC
+    - cron: "0 9 * * 1" # Monday 09:00 UTC
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/dependabot-weekly-report.yml
+++ b/.github/workflows/dependabot-weekly-report.yml
@@ -1,0 +1,56 @@
+name: Dependabot weekly report
+on:
+  schedule:
+    - cron: "9 9 * * 1" # Monday 09:09 UTC
+  workflow_dispatch:
+
+permissions:
+  issues: write
+  pull-requests: read
+
+jobs:
+  report:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/github-script@v7
+        with:
+          script: |
+            const { owner, repo } = context.repo;
+
+            // Fetch all open PRs from Dependabot
+            const { data: prs } = await github.rest.pulls.list({
+              owner, repo, state: 'open',
+              per_page: 100
+            });
+
+            const dependabotPRs = prs.filter(p => p.user.login === 'dependabot[bot]');
+
+            if (dependabotPRs.length === 0) {
+              const body = '## Dependabot Weekly Report\n\nNo open Dependabot PRs. All clear.';
+              await github.rest.issues.create({
+                owner, repo,
+                title: `Dependabot report ${new Date().toISOString().slice(0, 10)}`,
+                body,
+                labels: ['dependencies', 'automation']
+              });
+              return;
+            }
+
+            const lines = ['## Dependabot Weekly Report', '', '| PR | Age | Type | CI Status |', '|---|---|---|---|'];
+            const now = new Date();
+
+            for (const pr of dependabotPRs) {
+              const age = Math.floor((now - new Date(pr.created_at)) / (1000 * 60 * 60 * 24));
+              const labels = pr.labels.map(l => l.name).join(', ') || 'none';
+              const isMajor = labels.includes('major') ? '⚠️ major' : 'minor/patch';
+              lines.push(`| [#${pr.number}](${pr.html_url}) ${pr.title.slice(0, 50)} | ${age}d | ${isMajor} | ${pr.mergeable_state || 'unknown'} |`);
+            }
+
+            lines.push('', '---', '', `Report generated at ${now.toISOString()}`);
+
+            await github.rest.issues.create({
+              owner, repo,
+              title: `Dependabot report ${now.toISOString().slice(0, 10)}`,
+              body: lines.join('\n'),
+              labels: ['dependencies', 'automation']
+            });

--- a/pr-context.md
+++ b/pr-context.md
@@ -1,0 +1,28 @@
+# pr-context.md — PR for Dependabot automation
+
+**Branch:** `feat/dependabot-automation-1427`
+**Title:** feat(dependabot): group updates, auto-close vendored deps, auto-merge minor/patch, weekly report
+**Latest commit:** `cc5dcdcd`
+
+## Changes
+
+- `.github/dependabot.yml` — Group all minor+patch updates per ecosystem (`npm` root + `npm` frontend) into single PRs; cap `open-pull-requests-limit` at 5.
+- `.github/workflows/auto-merge-dependabot.yml` — Auto-merge (`--squash`) Dependabot minor/patch PRs on green CI. Skips `semver:major` and any PR touching the vendored `MyVisualEditor` tree.
+- `.github/workflows/close-vendored-deps.yml` — Auto-closes Dependabot PRs touching `docker/resources/extensions/MyVisualEditor/**` with an explanatory comment (vendored dead weight — not installed or executed in the built image).
+- `.github/workflows/dependabot-weekly-report.yml` — Weekly Monday (09:09 UTC) report issue of open Dependabot PRs with age/type/CI status; also `workflow_dispatch`-able.
+
+## Key decisions
+
+- Grouping uses a single `minor-patch` group with `update-types: [minor, patch]` and pattern `*` per ecosystem, matching standard GitHub grouping guidance.
+- `pull_request_target` used for the close/auto-merge workflows so they run with the required write permissions on the target branch; both gate strictly on `github.actor == 'dependabot[bot]'`.
+- `auto-merge-dependabot` re-checks vendored paths as a defense-in-depth guard even though `close-vendored-deps` handles them, so a vendored PR can never slip through auto-merge.
+- Vendored deps are intentionally closed rather than updated: the `MyVisualEditor` tree is copied verbatim into the MediaWiki container and never npm/composer-installed.
+- Weekly report creates an issue rather than a comment so it has a stable, findable home; uses `issues: write` only.
+
+## Open questions
+
+None.
+
+## /oc exchanges
+
+None yet.

--- a/pr-context.md
+++ b/pr-context.md
@@ -25,4 +25,4 @@ None.
 
 ## /oc exchanges
 
-None yet.
+- **2026-08-07, PR #1431 comment:** Changed weekly report cron from 09:09 to 09:00 UTC (`"9 9 * * 1"` → `"0 9 * * 1"`).


### PR DESCRIPTION
## Summary

- **Group updates** — minor+patch updates per ecosystem (`npm` root + `npm` frontend) collapse into single PRs; `open-pull-requests-limit` capped at 5.
- **Auto-close vendored deps** — Dependabot PRs touching `docker/resources/extensions/MyVisualEditor/**` are closed with an explanatory comment (dead weight — copied verbatim, never installed/executed).
- **Auto-merge minor/patch** — squashes Dependabot PRs on green CI; skips `semver:major` and vendored paths (defense-in-depth).
- **Weekly report** — Monday 09:09 UTC issue summarizing open Dependabot PRs (age/type/CI status); also `workflow_dispatch`-able.

Closes #1427

## Test Plan

- [ ] `dependabot.yml` passes Dependabot config validation (GitHub-side)
- [ ] `close-vendored-deps` workflow triggers on a vendored-deps Dependabot PR and closes it
- [ ] `auto-merge-dependabot` workflow skips major + vendored PRs, auto-merges a minor/patch PR on green CI
- [ ] `dependabot-weekly-report` can be run via `workflow_dispatch` and posts a report issue