### PR TITLE
ci: pass GITHUB_TOKEN to the opencode action step

### DIFF
--- a/.github/workflows/opencode.yml
+++ b/.github/workflows/opencode.yml
@@ -51,6 +51,9 @@ jobs:
         uses: anomalyco/opencode/github@77fc88c8ade8e5a620ebbe1197f3a572d29ae91a
         env:
           OPENROUTER_API_KEY: ${{ secrets.OPENROUTER_API_KEY }}
+          # The action requires GITHUB_TOKEN in the step env when
+          # use_github_token: true (GitHub does not inject it automatically).
+          GITHUB_TOKEN: ${{ github.token }}
         with:
           model: openrouter/deepseek/deepseek-v4-flash
           use_github_token: true

--- a/pr-context.md
+++ b/pr-context.md
@@ -1,0 +1,17 @@
+# PR Context — Pass GITHUB_TOKEN to the opencode action
+
+## Problem
+
+/oc test run (after the collaborator-gate fix) failed at the "Run opencode" step with:
+
+> GITHUB_TOKEN environment variable is not set. When using use_github_token, you must provide GITHUB_TOKEN.
+
+The `anomalyco/opencode/github` action requires `GITHUB_TOKEN` in the **step env** when `use_github_token: true` — GitHub does not inject it into steps automatically.
+
+## Fix
+
+Add `GITHUB_TOKEN: ${{ github.token }}` to the "Run opencode" step env (workflow-only change; no DB paths, so the DB change guard passes).
+
+## Verification
+
+After merge, post `/oc` and confirm the agent runs end-to-end: gate passes (Check repo access), action has the token, model call runs, reply posted.


### PR DESCRIPTION
## What & why

The `/oc` test showed the gate now works (collaborator check passed with the GITHUB_TOKEN — no PAT needed), but the opencode action step failed:

> `GITHUB_TOKEN environment variable is not set. When using use_github_token, you must provide GITHUB_TOKEN.`

The `anomalyco/opencode/github` action requires `GITHUB_TOKEN` in the **step env** when `use_github_token: true` — GitHub doesn't inject it automatically.

## Fix

Add `GITHUB_TOKEN: ${{ github.token }}` to the "Run opencode" step env.

Workflow-only change (no DB paths → the DB change guard passes).

## After merge

I'll post another `/oc` comment to confirm the agent runs end-to-end (gate → token → model call → reply).