### PR TITLE
ci: configure git identity on the /oc runner

### DIFF
--- a/.github/workflows/opencode.yml
+++ b/.github/workflows/opencode.yml
@@ -46,6 +46,14 @@ jobs:
               core.setOutput('can_trigger', 'false');
             }
 
+      - name: Configure git identity
+        if: steps.check.outputs.can_trigger == 'true'
+        run: |
+          # The runner has no git identity; without this the agent cannot commit/
+          # push its changes on the PR branch ("Please tell me who you are").
+          git config user.name "opencode[bot]"
+          git config user.email "opencode[bot]@users.noreply.github.com"
+
       - name: Run opencode
         if: steps.check.outputs.can_trigger == 'true'
         uses: anomalyco/opencode/github@77fc88c8ade8e5a620ebbe1197f3a572d29ae91a

--- a/pr-context.md
+++ b/pr-context.md
@@ -1,0 +1,24 @@
+# PR Context — Configure git identity for /oc on the runner
+
+## Problem
+
+On PR #1452, `/oc merge` was posted. The agent correctly declined the merge ("I cannot merge this PR — a human must do that") and tried to make a code fix instead, but **`git commit` failed on the CI runner**:
+
+> Author identity unknown — Please tell me who you are. … fatal: empty ident name (for <runner@…internal.cloudapp.net>)
+
+The runner has no git `user.name`/`user.email`, so the agent cannot commit/push changes — meaning `/oc` can't complete any fix/implementation task. The raw error also leaked into the posted reply (bad UX).
+
+## Fix
+
+Add a **"Configure git identity"** step before "Run opencode" in `.github/workflows/opencode.yml`:
+
+```yaml
+git config user.name "opencode[bot]"
+git config user.email "opencode[bot]@users.noreply.github.com"
+```
+
+## Verification
+
+- YAML validated (js-yaml).
+- After merge to main, `/oc` that makes a change should commit+push with the `opencode[bot]` identity instead of failing.
+- Workflow-only change (no DB paths) → DB change guard passes.


### PR DESCRIPTION
## What happened

On PR #1452, **`/oc merge`** was posted. The agent correctly declined ("I cannot merge this PR — a human must do that") and pivoted to make a code fix — but **`git commit` failed on the CI runner**:

```
Author identity unknown — Please tell me who you are.
fatal: empty ident name (for <runner@…internal.cloudapp.net>) not allowed
```

The runner has **no git `user.name`/`user.email`**, so the agent can't commit/push its changes — meaning `/oc` can't complete any fix/implementation task. The raw error also leaked into the posted reply.

## Fix

Added a **`Configure git identity`** step before `Run opencode` in `.github/workflows/opencode.yml`:

```yaml
- name: Configure git identity
  run: |
    git config user.name "opencode[bot]"
    git config user.email "opencode[bot]@users.noreply.github.com"
```

## Verification

- YAML validated.
- Workflow-only (no DB paths) → DB change guard passes.
- After merge to main, `/oc` changes should commit+push as `opencode[bot]` instead of failing.
