### PR TITLE
ci: give /oc agent git push auth via GITHUB_TOKEN

### DIFF
--- a/.github/workflows/opencode.yml
+++ b/.github/workflows/opencode.yml
@@ -50,11 +50,17 @@ jobs:
 
       - name: Configure git identity
         if: steps.check.outputs.can_trigger == 'true'
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
         run: |
-          # The runner has no git identity; without this the agent cannot commit/
-          # push its changes on the PR branch ("Please tell me who you are").
+          # The runner has no git identity; without this the agent cannot commit
+          # ("Please tell me who you are").
           git config user.name "opencode[bot]"
           git config user.email "opencode[bot]@users.noreply.github.com"
+          # actions/checkout uses persist-credentials: false, so no push auth is
+          # left behind; without this the agent's 'git push' fails
+          # ("could not read Username for 'https://github.com'").
+          git config --local http.https://github.com/.extraheader "AUTHORIZATION: basic $(printf 'x-access-token:%s' "$GITHUB_TOKEN" | base64)"
 
       - name: Run opencode
         if: steps.check.outputs.can_trigger == 'true'

--- a/pr-context.md
+++ b/pr-context.md
@@ -1,0 +1,25 @@
+# PR Context — Give /oc agent git push auth (GITHUB_TOKEN)
+
+## Problem
+
+On PR #1449, `/oc add screenshots...` → the agent made the changes but `git push` failed:
+
+> fatal: could not read Username for 'https://github.com': No such device or address
+
+Root cause: the workflow's `actions/checkout` uses **`persist-credentials: false`**, so checkout removes the git credentials after checkout ("Removing includeIf entries pointing to credentials config files"). The git-identity fix (#1454) covered `user.name`/`user.email` but not **push auth** — the agent has the GITHUB_TOKEN in env but git has no credentials configured.
+
+## Fix
+
+In the existing "Configure git identity" step, add the GITHUB_TOKEN as git HTTP auth for the workdir (same `x-access-token` basic scheme actions/checkout uses):
+
+```bash
+git config --local http.https://github.com/.extraheader "AUTHORIZATION: basic $(printf 'x-access-token:%s' "$GITHUB_TOKEN" | base64)"
+```
+
+## Note
+
+The first `/oc` in that exchange (12:38) replied with a PR summary instead of executing the screenshot task — a separate model-execution flub, not covered by this fix.
+
+## Verify after merge
+
+Post `/oc <task that changes files>` on a PR → the agent should commit and push successfully (previously failed with "could not read Username").


### PR DESCRIPTION
## Diagnosis (PR #1449 /oc exchange)

On `/oc add screenshots…`, the agent made the changes but **`git push` failed**:

```
fatal: could not read Username for 'https://github.com': No such device or address
```

**Root cause:** the workflow's `actions/checkout` uses **`persist-credentials: false`**, so checkout removes the git credentials after checkout. The #1454 git-identity fix covered `user.name`/`user.email` but not **push auth** — the agent has the GITHUB_TOKEN in env, but git has no credentials.

## Fix

In the existing `Configure git identity` step, configure the GITHUB_TOKEN as git HTTP auth (the `x-access-token` basic scheme actions/checkout uses):

```bash
git config --local http.https://github.com/.extraheader "AUTHORIZATION: basic $(printf 'x-access-token:%s' "$GITHUB_TOKEN" | base64)"
```

## Note

The first `/oc` in that exchange (12:38) replied with a PR summary instead of executing — a separate model-execution flub, not fixed here.

## After merge

Post `/oc <task that changes files>` → the agent should now commit and push successfully.
