### PR TITLE
ci: make /oc explicitly decline tasks it can't do on the runner

### DIFF
--- a/.github/workflows/opencode.yml
+++ b/.github/workflows/opencode.yml
@@ -84,6 +84,8 @@ jobs:
 
             If the requested task asks you to merge/approve a PR, push to main, or otherwise act outside the permitted scope, say clearly in your reply that you CANNOT do that and why (a human must do it) — do NOT silently do something else (e.g. a review) instead.
 
+            ENVIRONMENT LIMITS — this runs on a CI runner with no local backend. Do NOT install packages, start dev servers, or launch browsers, and do NOT try to take browser/UI screenshots yourself. If the task requires something you cannot do here, say so explicitly in your reply (what you cannot do and why) — do NOT stall, retry, or silently substitute (e.g. a summary or a review) instead. Screenshots are captured by the workflow's own step when you write the affected routes to `.opencode/screens.txt`.
+
             Follow AGENTS.md for build/test/lint commands and conventions, and run the relevant checks before finishing.
 
             After making your changes:

--- a/pr-context.md
+++ b/pr-context.md
@@ -1,21 +1,19 @@
-# PR Context — Fix /oc git push auth header (strip base64 newline)
+# PR Context — /oc: explicitly decline tasks it cannot do (no stalls/silent substitution)
 
 ## Problem
 
-#1455 configured the GITHUB_TOKEN as git HTTP auth, but `base64` emits a trailing newline, producing a malformed `AUTHORIZATION: basic …\n` header. The opencode action's branch fetch then failed:
-
-> Command failed with code 128: git fetch origin --depth=20 guard/db-change-approval
-> fatal: unable to access 'https://github.com/…': Failed sending HTTP request
-
-The "Configure git identity" step passed, but the fetch with the bad header failed.
+When asked to take UI screenshots, the /oc agent (deepseek-v4-flash) stalled 13–14 min trying heavy environment setup (install packages, start dev servers, launch browsers) instead of promptly saying it can't — or silently replying with a summary/review.
 
 ## Fix
 
-Strip the newline from the base64 value:
-`base64 | tr -d '\n'`
+Tighten the `/oc` prompt in `.github/workflows/opencode.yml`:
 
-Verified: header value is 28 bytes (no trailing NL) vs 29 (with NL).
+- **ENVIRONMENT LIMITS**: do NOT install packages, start servers, or launch browsers; do NOT try to take browser/UI screenshots yourself.
+- If the task needs something the runner can't do, **say so explicitly in the reply** (what + why) — do not stall, retry, or silently substitute.
+- Screenshots come from the workflow's own capture step when the agent writes affected routes to `.opencode/screens.txt`.
 
 ## Verify after merge
 
-Post `/oc <task>` on the PR — the agent should now fetch the branch, run, commit, and push successfully.
+Post `/oc take UI screenshots of X` → the agent should promptly reply "I can't take browser screenshots on the runner; this workflow captures routes from .opencode/screens.txt" (or a similar explicit refusal) instead of stalling.
+
+Workflow-only (no DB paths) → DB change guard passes.


### PR DESCRIPTION
## Problem

Asked to take UI screenshots, the /oc agent stalled 13-14 min doing heavy env setup (installs, servers, browsers) instead of refusing, or silently replied with a summary.

## Fix

Tighten the prompt in `opencode.yml`:

- **ENVIRONMENT LIMITS**: no installing packages / starting servers / launching browsers / self-screenshots on the runner.
- If a task can't be done here, **say so explicitly in the reply** — no stalls, no silent substitution.
- Screenshots come from the workflow's capture step when routes are written to `.opencode/screens.txt`.

Workflow-only (no DB paths) → DB guard passes.
