### PR TITLE
ci: approve-handler pushes a head commit so the gate re-runs on the head

### DIFF
--- a/.github/workflows/approve-handler.yml
+++ b/.github/workflows/approve-handler.yml
@@ -13,6 +13,7 @@ on:
     types: [created]
 
 permissions:
+  contents: write
   pull-requests: write
   issues: write
 
@@ -52,3 +53,39 @@ jobs:
               labels: ['human-approved'],
             });
             console.log(`added human-approved to #${context.payload.issue.number} via @${author}`);
+
+            // Push a head commit so the gate re-runs on the head commit. A
+            // token-added label doesn't fire `labeled`, and issue_comment runs
+            // aren't attached to the head — a synchronize (head commit) is what
+            // turns the required `human-approval-gate` check green.
+            const { data: pr } = await github.rest.pulls.get({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: context.payload.issue.number,
+            });
+            const branch = pr.head.ref;
+            const content = Buffer.from(
+              `approved by ${author} at ${new Date().toISOString()}\n`,
+            ).toString('base64');
+            let sha;
+            try {
+              const { data: existing } = await github.rest.repos.getContent({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                path: '.opencode/approved',
+                ref: branch,
+              });
+              sha = existing.sha;
+            } catch (e) {
+              // 404 -> create the marker.
+            }
+            await github.rest.repos.createOrUpdateFileContents({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              path: '.opencode/approved',
+              message: 'ci: record human approval',
+              content,
+              branch,
+              ...(sha ? { sha } : {}),
+            });
+            console.log(`pushed approval marker to ${branch}`);

--- a/.github/workflows/approve-handler.yml
+++ b/.github/workflows/approve-handler.yml
@@ -13,7 +13,7 @@ on:
     types: [created]
 
 permissions:
-  contents: write
+  actions: write
   pull-requests: write
   issues: write
 
@@ -54,38 +54,31 @@ jobs:
             });
             console.log(`added human-approved to #${context.payload.issue.number} via @${author}`);
 
-            // Push a head commit so the gate re-runs on the head commit. A
+            // Re-run ONLY the human-approval-gate check on the head commit. A
             // token-added label doesn't fire `labeled`, and issue_comment runs
-            // aren't attached to the head — a synchronize (head commit) is what
-            // turns the required `human-approval-gate` check green.
+            // aren't attached to the head — so re-run the gate's head-attached
+            // run directly (no new commit, no full CI re-run).
             const { data: pr } = await github.rest.pulls.get({
               owner: context.repo.owner,
               repo: context.repo.repo,
               pull_number: context.payload.issue.number,
             });
-            const branch = pr.head.ref;
-            const content = Buffer.from(
-              `approved by ${author} at ${new Date().toISOString()}\n`,
-            ).toString('base64');
-            let sha;
-            try {
-              const { data: existing } = await github.rest.repos.getContent({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                path: '.opencode/approved',
-                ref: branch,
-              });
-              sha = existing.sha;
-            } catch (e) {
-              // 404 -> create the marker.
-            }
-            await github.rest.repos.createOrUpdateFileContents({
+            const headSha = pr.head.sha;
+            const { data: runs } = await github.rest.actions.listWorkflowRunsForRepo({
               owner: context.repo.owner,
               repo: context.repo.repo,
-              path: '.opencode/approved',
-              message: 'ci: record human approval',
-              content,
-              branch,
-              ...(sha ? { sha } : {}),
+              workflow_id: 'human-approval-gate.yml',
+              head_sha: headSha,
+              per_page: 1,
             });
-            console.log(`pushed approval marker to ${branch}`);
+            const run = runs.workflow_runs && runs.workflow_runs[0];
+            if (run) {
+              await github.rest.actions.reRunWorkflow({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                run_id: run.id,
+              });
+              console.log(`re-ran human-approval-gate run ${run.id} on ${headSha}`);
+            } else {
+              console.log('no human-approval-gate run on head; skipping re-run');
+            }


### PR DESCRIPTION
## Why

`/approve` never turned the **`human-approval-gate`** check green on the PR **head commit**:
- A token-added `human-approved` label doesn't fire a `labeled` event (GitHub skips workflows for GITHUB_TOKEN events).
- `issue_comment`-triggered gate runs aren't attached to the PR head commit, so they don't satisfy the *required* check.

So the head-commit check stayed at its pre-approval failing state.

## Fix

`approve-handler`, after adding `human-approved`, **re-runs only the `human-approval-gate` workflow run on the head commit** via the API (`actions: write`). The gate re-evaluates with the label present and passes — **no new commit, no full CI re-run** (only the gate re-runs, exactly as needed on a label change).

Workflow-only (no DB paths).
